### PR TITLE
Codestyle fixes. Adding missed phpDoc. className -> static in methods…

### DIFF
--- a/src/Auth/Authentication.php
+++ b/src/Auth/Authentication.php
@@ -7,7 +7,8 @@ namespace Microsoft\BingAds\Auth;
  */
 abstract class Authentication
 {
-    /** 
+    /**
+     * @var string
      * The Authentication type for example PasswordAuthentication or OAuthDesktopMobileImplicitGrant.
      */
     public $Type;

--- a/src/Auth/AuthorizationData.php
+++ b/src/Auth/AuthorizationData.php
@@ -7,22 +7,26 @@ namespace Microsoft\BingAds\Auth;
  */
 class AuthorizationData
 {
-    /** 
+    /**
+     * @var OAuthAuthorization
      * An object representing the authentication headers that should be used in calls to the Bing Ads web services.
      */
     public $Authentication;
 
-    /** 
+    /**
+     * @var string
      * The identifier of the account that owns the entities in the request. Used as the CustomerAccountId header element in calls to the Bing Ads web services.
      */
     public $AccountId;
 
-    /** 
+    /**
+     * @var string
      * The identifier of the customer that owns the account. Used as the CustomerId header element in calls to the Bing Ads web services.
      */
     public $CustomerId;
 
-    /** 
+    /**
+     * @var string
      * The Bing Ads developer access token. Used as the DeveloperToken header element in calls to the Bing Ads web services.
      */
     public $DeveloperToken;
@@ -34,7 +38,7 @@ class AuthorizationData
      * Includes the authentication. 
      *
      * @param Authentication $authentication
-     * @return AuthorizationData this builder
+     * @return static this builder
      */
     public function withAuthentication($authentication) {
         $this->Authentication = $authentication;
@@ -45,7 +49,7 @@ class AuthorizationData
      * Includes the account ID. 
      *
      * @param string $accountId
-     * @return AuthorizationData this builder
+     * @return static this builder
      */
     public function withAccountId($accountId) {
         $this->AccountId = $accountId;
@@ -56,7 +60,7 @@ class AuthorizationData
      * Includes the customer ID. 
      *
      * @param string $customerId
-     * @return AuthorizationData this builder
+     * @return static this builder
      */
     public function withCustomerId($customerId) {
         $this->CustomerId = $customerId;
@@ -67,7 +71,7 @@ class AuthorizationData
      * Includes the developer token. 
      *
      * @param string $developerToken
-     * @return AuthorizationData this builder
+     * @return static this builder
      */
     public function withDeveloperToken($developerToken) {
         $this->DeveloperToken = $developerToken;

--- a/src/Auth/IOAuthService.php
+++ b/src/Auth/IOAuthService.php
@@ -7,11 +7,13 @@ namespace Microsoft\BingAds\Auth;
  */
 abstract class IOAuthService
 {
-    /** 
-     * Implementations of this abstract method must call the authorization server with the oauthRequestParameters passed in, 
+    /**
+     * Implementations of this abstract method must call the authorization server with the oauthRequestParameters passed in,
      * deserialize the response, and return back OAuth tokens.
+     * @param OAuthRequestParameters $oauthParameters
+     * @return OAuthTokens
      */
-    abstract function GetAccessTokens(OAuthRequestParameters $oauthParameters);
+    abstract public function GetAccessTokens(OAuthRequestParameters $oauthParameters);
 }
 
 ?>

--- a/src/Auth/OAuthAuthorization.php
+++ b/src/Auth/OAuthAuthorization.php
@@ -7,28 +7,31 @@ namespace Microsoft\BingAds\Auth;
  */
 abstract class OAuthAuthorization extends Authentication 
 {
-    /** 
+    /**
+     * @var string
      * The client identifier corresponding to your registered application.
      */
     public $ClientId;
  
-    /** 
+    /**
+     * @var OAuthTokens
      * Contains information about OAuth access tokens received from the Microsoft Account authorization service.
      */
     public $OAuthTokens;
 
-    /** 
+    /**
+     * @var string
      * The URI to which the user of the app will be redirected after receiving user consent.
      */
     public $RedirectUri;
 
     public function __construct() {}
 
-    /** 
+    /**
      * Includes the client ID. 
      *
      * @param string $clientId
-     * @return OAuthAuthorization this builder
+     * @return static this builder
      */
     public function withClientId($clientId) {
         $this->ClientId = $clientId;
@@ -39,18 +42,18 @@ abstract class OAuthAuthorization extends Authentication
      * Includes the redirect URI. 
      *
      * @param string $redirectUri
-     * @return OAuthAuthorization this builder
+     * @return static this builder
      */
     public function withRedirectUri($redirectUri) {
         $this->RedirectUri = $redirectUri;
         return $this;
     }
 
-    /** 
+    /**
      * Includes the refresh token. 
      *
      * @param string $refreshToken
-     * @return OAuthAuthorization this builder
+     * @return static this builder
      */
     public function withRefreshToken($refreshToken) {
         $this->OAuthTokens = (new OAuthTokens())->withRefreshToken($refreshToken);
@@ -61,14 +64,14 @@ abstract class OAuthAuthorization extends Authentication
      * Includes the OAuth tokens. 
      *
      * @param string $oauthTokens
-     * @return OAuthAuthorization this builder
+     * @return static this builder
      */
     public function withOAuthTokens($oauthTokens) {
         $this->OAuthTokens = $oauthTokens;
         return $this;
     }
    
-    /** 
+    /**
      * Implementations of this abstract method will get the Microsoft Account authorization endpoint 
      * where the user should be navigated to give their consent.
      */

--- a/src/Auth/OAuthDesktopMobileImplicitGrant.php
+++ b/src/Auth/OAuthDesktopMobileImplicitGrant.php
@@ -24,7 +24,7 @@ class OAuthDesktopMobileImplicitGrant extends OAuthAuthorization
      * Includes the state. 
      *
      * @param string $state
-     * @return OAuthDesktopMobileImplicitGrant this builder
+     * @return static this builder
      */
     public function withState($state) {
         $this->State = $state;

--- a/src/Auth/OAuthRequestParameters.php
+++ b/src/Auth/OAuthRequestParameters.php
@@ -7,35 +7,41 @@ namespace Microsoft\BingAds\Auth;
  */
 class OAuthRequestParameters
 {
-    /** 
+    /**
+     * @var string
      * Your application's registered client identifier.
      */
     public $ClientId;
 
-    /** 
+    /**
+     * @var string
      * Your application's registered client secret. 
      * This parameter is required with OAuthWebAuthCodeGrant requests. 
      */
     public $ClientSecret;
 
-    /** 
+    /**
+     * @var string
      * The URI where you want the authorization response to be redirected.
      */
     public $RedirectUri;
 
     /**
+     * @var string
      * The authorization grant param name. 
      * For example the grant param name could be 'refresh_token' or 'authorization_code'.
      */
     public $GrantType;
 
     /**
+     * @var string
      * The authorization grant param name. 
      * For example the grant param name could be 'refresh_token' or 'code'.
      */
     public $GrantParamName;
 
     /**
+     * @var string
      * The value depends on the $GrantType and $GrantParamName. 
      * For example if $GrantType and $GrantParamName are both set to 'refresh_token',
      * the value is equal to the last known and valid refresh token.
@@ -48,7 +54,7 @@ class OAuthRequestParameters
      * Includes the client ID. 
      *
      * @param string $clientId
-     * @return OAuthRequestParameters this builder
+     * @return static this builder
      */
     public function withClientId($clientId) {
         $this->ClientId = $clientId;
@@ -59,7 +65,7 @@ class OAuthRequestParameters
      * Includes the client secret. 
      *
      * @param string $clientSecret
-     * @return OAuthRequestParameters this builder
+     * @return static this builder
      */
     public function withClientSecret($clientSecret) {
         $this->ClientSecret = $clientSecret;
@@ -70,7 +76,7 @@ class OAuthRequestParameters
      * Includes the redirect URI. 
      *
      * @param string $redirectUri
-     * @return OAuthRequestParameters this builder
+     * @return static this builder
      */
     public function withRedirectUri($redirectUri) {
         $this->RedirectUri = $redirectUri;
@@ -81,7 +87,7 @@ class OAuthRequestParameters
      * Includes the grant type. 
      *
      * @param string $grantType
-     * @return OAuthRequestParameters this builder
+     * @return static this builder
      */
     public function withGrantType($grantType) {
         $this->GrantType = $grantType;
@@ -92,7 +98,7 @@ class OAuthRequestParameters
      * Includes the grant param name. 
      *
      * @param string $grantParamName
-     * @return OAuthRequestParameters this builder
+     * @return static this builder
      */
     public function withGrantParamName($grantParamName) {
         $this->GrantParamName = $grantParamName;
@@ -103,7 +109,7 @@ class OAuthRequestParameters
      * Includes the grant value. 
      *
      * @param string $grantValue
-     * @return OAuthRequestParameters this builder
+     * @return static this builder
      */
     public function withGrantValue($grantValue) {
         $this->GrantValue = $grantValue;

--- a/src/Auth/OAuthTokens.php
+++ b/src/Auth/OAuthTokens.php
@@ -7,17 +7,20 @@ namespace Microsoft\BingAds\Auth;
  */
 class OAuthTokens
 {   
-    /** 
+    /**
+     * @var string
      * Represents the access_token value returned by the authorization service.
      */
     public $AccessToken;
 
-    /** 
+    /**
+     * @var int
      * Represents the expires_in value returned by the authorization service.
      */
     public $AccessTokenExpiresInSeconds;
 
-    /** 
+    /**
+     * @var string
      * Represents the refresh_token value returned or sent via the authorization service.
      */
     public $RefreshToken;
@@ -35,6 +38,7 @@ class OAuthTokens
 
     /** 
      * Includes the access token.
+     * @return static
      */
     public function withAccessToken($accessToken) {
         $this->AccessToken = $accessToken;
@@ -43,14 +47,17 @@ class OAuthTokens
 
     /** 
      * Includes the access token expiration time in seconds.
+     * @return static
      */
     public function withAccessTokenExpiresInSeconds($accessTokenExpiresInSeconds) {
         $this->AccessTokenExpiresInSeconds = $accessTokenExpiresInSeconds;
         return $this;
     }
 
-    /** 
+    /**
      * Includes the refresh token.
+     * @param $refreshToken
+     * @return static
      */
     public function withRefreshToken($refreshToken) {
         $this->RefreshToken = $refreshToken;

--- a/src/Auth/OAuthUrlParameters.php
+++ b/src/Auth/OAuthUrlParameters.php
@@ -7,24 +7,28 @@ namespace Microsoft\BingAds\Auth;
  */
 class OAuthUrlParameters
 {
-    /** 
+    /**
+     * @var string
      * Your application's registered client identifier.
      */
     public $ClientId;
 
-    /** 
+    /**
+     * @var string
      * The authorization response type. 
      * For implicit grant flow, the response type is 'token'.
      * For authorization code grant flow, the response type is 'code'.
      */
     public $ResponseType;
 
-    /** 
+    /**
+     * @var string
      * The URI where you want the authorization response to be redirected.
      */
     public $RedirectUri;
 
-    /** 
+    /**
+     * @var string
      * An opaque value used by the client to maintain state between the request and callback.
      */
     public $State;
@@ -35,7 +39,7 @@ class OAuthUrlParameters
      * Includes the client ID. 
      *
      * @param string $clientId
-     * @return OAuthUrlParameters this builder
+     * @return static this builder
      */
     public function withClientId($clientId) {
         $this->ClientId = $clientId;
@@ -46,7 +50,7 @@ class OAuthUrlParameters
      * Includes the response type. 
      *
      * @param string $responseType
-     * @return OAuthUrlParameters this builder
+     * @return static this builder
      */
     public function withResponseType($responseType) {
         $this->ResponseType = $responseType;
@@ -57,7 +61,7 @@ class OAuthUrlParameters
      * Includes the redirect URI. 
      *
      * @param string $redirectUri
-     * @return OAuthUrlParameters this builder
+     * @return static this builder
      */
     public function withRedirectUri($redirectUri) {
         $this->RedirectUri = $redirectUri;
@@ -68,7 +72,7 @@ class OAuthUrlParameters
      * Includes the state. 
      *
      * @param string $state
-     * @return OAuthUrlParameters this builder
+     * @return static this builder
      */
     public function withState($state) {
         $this->State = $state;

--- a/src/Auth/OAuthWebAuthCodeGrant.php
+++ b/src/Auth/OAuthWebAuthCodeGrant.php
@@ -2,8 +2,6 @@
 
 namespace Microsoft\BingAds\Auth;
 
-use Exception;
-
 /** 
  * Represents an OAuth authorization object implementing the authorization code grant flow for use in a desktop or mobile application. 
  */

--- a/src/Auth/PasswordAuthentication.php
+++ b/src/Auth/PasswordAuthentication.php
@@ -7,24 +7,34 @@ namespace Microsoft\BingAds\Auth;
  */
 class PasswordAuthentication extends Authentication 
 {
+    /**
+     * @var string
+     */
     public $UserName;
 
+    /**
+     * @var string
+     */
     public $Password;
 
     public function __construct() {
         $this->Type = 'PasswordAuthentication';
     }
 
-    /** 
+    /**
      * Includes the user name.
+     * @param string $userName
+     * @return static
      */
     public function withUserName($userName) {
         $this->UserName = $userName;
         return $this;
     }
 
-    /** 
+    /**
      * Includes the password.
+     * @param $password
+     * @return static
      */
     public function withPassword($password) {
         $this->Password = $password;

--- a/src/Auth/ServiceClient.php
+++ b/src/Auth/ServiceClient.php
@@ -123,8 +123,6 @@ class ServiceClient
 		$this->namespace = $this->serviceClientNamespaces[$serviceClientType];
 
 		$this->SetAuthorizationData($authorizationData);
-		
-		return $this;
 	}
 
 	public function GetAccountId() { return $this->accountId; }


### PR DESCRIPTION
… which returns $this.

Hi guys. To use correct autocomplete and type highlighting in IDE, like PhpStorm let's use `static` keyword instead of class name in `@return` block. 

In this case IDE will notify us that `methodFromB()` doesn't exist, because it will expect that method `iWillReturnThis` returns class `A`: 
```php
class A {
 /**
  * @return A
  */
  public function iWillReturnThis() { 
    return $this; 
  }
} 

class B extends A {
  public function methodFromB() { }
}

(new B())->iWillReturnThis()->methodFromB()
```
 
In this case it works well:
```php
class A {
 /**
  * @return static
  */
  public function iWillReturnThis() { 
    return $this; 
  }
} 
...
```

And to make fluent interface highlighting works well with `public` properties, let's use phpDoc `@var` near property declaration, like: 
```php
class A {
  /** @var B */
  public $B;
}
class B {
  public function method();
}

(new A())->B->method()
```