### PR TITLE
search size

### DIFF
--- a/src/V11/CampaignManagement/AdGroupAdditionalField.php
+++ b/src/V11/CampaignManagement/AdGroupAdditionalField.php
@@ -12,7 +12,7 @@ namespace Microsoft\BingAds\V11\CampaignManagement;
      */
     final class AdGroupAdditionalField
     {
-        /** Includes the InheritedBidStrategyType element that can be nested within the BiddingScheme element of an AdGroup object. */
+        /** Request that the InheritedBidStrategyType element be included within each returned InheritFromParentBiddingScheme object (nested within the BiddingScheme element of an AdGroup). */
         const InheritedBidStrategyType = 'InheritedBidStrategyType';
     }
 

--- a/src/V11/CampaignManagement/AdStatus.php
+++ b/src/V11/CampaignManagement/AdStatus.php
@@ -11,7 +11,7 @@ namespace Microsoft\BingAds\V11\CampaignManagement;
      */
     final class AdStatus
     {
-        /** The ad is undergoing editorial review or has failed editorial review. */
+        /** This status is read-only. */
         const Inactive = 'Inactive';
 
         /** The ad can be served. */

--- a/src/V11/CampaignManagement/Audience.php
+++ b/src/V11/CampaignManagement/Audience.php
@@ -59,6 +59,12 @@ namespace Microsoft\BingAds\V11\CampaignManagement;
         public $Scope;
 
         /**
+         * The total number of people who belong to this audience.
+         * @var integer
+         */
+        public $SearchSize;
+
+        /**
          * The type of the audience.
          * @var AudienceType
          */

--- a/src/V11/CampaignManagement/AudienceAdditionalField.php
+++ b/src/V11/CampaignManagement/AudienceAdditionalField.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Microsoft\BingAds\V11\CampaignManagement;
+
+{
+    /**
+     * Defines a list of optional Audience properties that you can request when calling GetAudiencesByIds.
+     * @link https://docs.microsoft.com/en-us/bingads/campaign-management-service/audienceadditionalfield?view=bingads-11 AudienceAdditionalField Value Set
+     * 
+     * @used-by GetAudiencesByIdsRequest
+     */
+    final class AudienceAdditionalField
+    {
+        /** Request that the SearchSize element be included within each returned Audience object. */
+        const SearchSize = 'SearchSize';
+    }
+
+}

--- a/src/V11/CampaignManagement/GetAudiencesByIdsRequest.php
+++ b/src/V11/CampaignManagement/GetAudiencesByIdsRequest.php
@@ -8,6 +8,7 @@ namespace Microsoft\BingAds\V11\CampaignManagement;
      * @link https://docs.microsoft.com/en-us/bingads/campaign-management-service/getaudiencesbyids?view=bingads-11 GetAudiencesByIds Request Object
      * 
      * @uses AudienceType
+     * @uses AudienceAdditionalField
      * @used-by BingAdsCampaignManagementService::GetAudiencesByIds
      */
     final class GetAudiencesByIdsRequest
@@ -23,5 +24,11 @@ namespace Microsoft\BingAds\V11\CampaignManagement;
          * @var AudienceType
          */
         public $Type;
+
+        /**
+         * The list of additional properties that you want included within each returned Audience object.
+         * @var AudienceAdditionalField
+         */
+        public $ReturnAdditionalFields;
     }
 }

--- a/src/V11/CampaignManagement/KeywordAdditionalField.php
+++ b/src/V11/CampaignManagement/KeywordAdditionalField.php
@@ -13,7 +13,7 @@ namespace Microsoft\BingAds\V11\CampaignManagement;
      */
     final class KeywordAdditionalField
     {
-        /** Includes the InheritedBidStrategyType element that can be nested within the BiddingScheme element of an Keyword object. */
+        /** Request that the InheritedBidStrategyType element be included within each returned InheritFromParentBiddingScheme object (nested within the BiddingScheme element of a Keyword). */
         const InheritedBidStrategyType = 'InheritedBidStrategyType';
     }
 


### PR DESCRIPTION
The Campaign Management proxies are updated to support [audience search size](https://docs.microsoft.com/en-us/bingads/guides/release-notes#audiencesearchsize-january2018).