### PR TITLE
july refresh

### DIFF
--- a/src/Auth/LiveComOAuthService.php
+++ b/src/Auth/LiveComOAuthService.php
@@ -51,7 +51,8 @@ class LiveComOAuthService extends IOAuthService
             'client_id' => $oauthRequestParameters->ClientId,
             'grant_type' => $oauthRequestParameters->GrantType,
             $oauthRequestParameters->GrantParamName => $oauthRequestParameters->GrantValue,
-            'redirect_uri' => $oauthRequestParameters->RedirectUri
+            'redirect_uri' => $oauthRequestParameters->RedirectUri,
+            'scope' => 'bingads.manage'
         );
 
         if ($oauthRequestParameters->ClientSecret != null)

--- a/src/V12/CampaignManagement/AdGroup.php
+++ b/src/V12/CampaignManagement/AdGroup.php
@@ -91,7 +91,7 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
         public $PrivacyStatus;
 
         /**
-         * The ad group settings for criterion type group targets.
+         * The ad group settings that typically vary by campaign type.
          * @var Setting[]
          */
         public $Settings;

--- a/src/V12/CampaignManagement/CoOpSetting.php
+++ b/src/V12/CampaignManagement/CoOpSetting.php
@@ -12,7 +12,7 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
     final class CoOpSetting extends Setting
     {
         /**
-         * The percentage that allows your cooperative bid to flex.
+         * The percentage (greater than zero) that allows your cooperative bid to flex.
          * @var double
          */
         public $BidBoostValue;

--- a/src/V12/CampaignManagement/Network.php
+++ b/src/V12/CampaignManagement/Network.php
@@ -20,7 +20,7 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
         /** Display ads on only syndicated search networks. */
         const SyndicatedSearchOnly = 'SyndicatedSearchOnly';
 
-        /** Reserved. */
+        /** Reserved for future use. */
         const InHousePromotion = 'InHousePromotion';
     }
 

--- a/src/V12/CampaignManagement/ProductAd.php
+++ b/src/V12/CampaignManagement/ProductAd.php
@@ -10,7 +10,7 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
     final class ProductAd extends Ad
     {
         /**
-         * The promotional text to display in a product ad.
+         * This property is reserved for internal use and will be removed from a future version of the API.
          * @var string
          */
         public $PromotionalText;

--- a/src/V12/CampaignManagement/ShoppingSetting.php
+++ b/src/V12/CampaignManagement/ShoppingSetting.php
@@ -28,7 +28,7 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
         public $SalesCountryCode;
 
         /**
-         * The unique identifier for the Bing Merchant Center store that your product catalog feed belongs to.
+         * The unique identifier for the Bing Merchant Center store that contains a product catalog feed that you want to use for the campaign.
          * @var integer
          */
         public $StoreId;

--- a/src/V12/CustomerManagement/CustomerRole.php
+++ b/src/V12/CustomerManagement/CustomerRole.php
@@ -28,6 +28,12 @@ namespace Microsoft\BingAds\V12\CustomerManagement;
          * @var integer[]
          */
         public $AccountIds;
+
+        /**
+         * Reserved.
+         * @var integer[]
+         */
+        public $LinkedAccountIds;
     }
 
 }

--- a/src/V12/CustomerManagement/GetUserRequest.php
+++ b/src/V12/CustomerManagement/GetUserRequest.php
@@ -16,5 +16,11 @@ namespace Microsoft\BingAds\V12\CustomerManagement;
          * @var integer
          */
         public $UserId;
+
+        /**
+         * Reserved.
+         * @var boolean
+         */
+        public $IncludeLinkedAccountIds;
     }
 }


### PR DESCRIPTION
* Limited the scope to bingads.manage for access token requests. Previously the default scope was used, which can vary if a user granted your app permissions to multiple scopes. The Bing Ads SDKs only support the bingads.manage scope. 
* Updated the Customer Management proxies to support [LinkedAccountIds](https://docs.microsoft.com/en-us/bingads/guides/release-notes?view=bingads-12#linkedaccountids-june2018) for agencies. For agency users the customer role can contain a list of linked accounts that the user can access as an agency on behalf of another customer.