### PR TITLE
Remove duplicate dependencies from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,6 @@
         "ext-openssl": "*",
         "ext-soap": "*"
     },
-    "require-dev": {
-        "ext-curl": "*",
-        "ext-openssl": "*",
-        "ext-soap": "*"
-    },
     "autoload": {
         "psr-4": {
             "Microsoft\\BingAds\\": "/src/"


### PR DESCRIPTION
The dependencies listed in `require-dev` are added to the regular ones in `required`, so there's no need to duplicate this list.