### PR TITLE
Prevent parse error with PHP 5

### DIFF
--- a/src/V12/AdInsight/CurrencyCode.php
+++ b/src/V12/AdInsight/CurrencyCode.php
@@ -253,7 +253,8 @@ namespace Microsoft\BingAds\V12\AdInsight;
         const TND = 'TND';
 
         /** The corresponding currency type. */
-        const TRY = 'TRY';
+        // 'TRY' is a reserved keyword in PHP5
+        const TRYx = 'TRY';
 
         /** The corresponding currency type. */
         const TTD = 'TTD';

--- a/src/V12/CustomerManagement/CurrencyCode.php
+++ b/src/V12/CustomerManagement/CurrencyCode.php
@@ -249,7 +249,8 @@ namespace Microsoft\BingAds\V12\CustomerManagement;
         const TND = 'TND';
 
         /** The corresponding currency type. */
-        const TRY = 'TRY';
+        // 'TRY' is a reserved keyword in PHP5
+        const TRYx = 'TRY';
 
         /** The corresponding currency type. */
         const TTD = 'TTD';


### PR DESCRIPTION
In PHP 5.6 (which is still supported by this library) a class constant cannot be named `TRY`. This leads to a Parse Error as soon as the class `CurrencyCode` is autoloaded in any way.

This fix, while not as pretty, will still work fine with IDE auto completion.