### PR TITLE
proxy refresh and min php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "type": "library",
     "homepage": "https://github.com/BingAds/BingAds-PHP-SDK",
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.1",
         "ext-curl": "*",
         "ext-openssl": "*",
         "ext-soap": "*"

--- a/src/V12/Bulk/GetBulkUploadUrlResponse.php
+++ b/src/V12/Bulk/GetBulkUploadUrlResponse.php
@@ -18,7 +18,7 @@ namespace Microsoft\BingAds\V12\Bulk;
         public $RequestId;
 
         /**
-         * The URL where you may submit your bulk upload file with  HTTP POST.
+         * The URL where you may submit your bulk upload file via HTTP POST.
          * @var string
          */
         public $UploadUrl;

--- a/src/V12/CampaignManagement/AccountPropertyName.php
+++ b/src/V12/CampaignManagement/AccountPropertyName.php
@@ -23,6 +23,9 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
 
         /** Used to get or set the property that determines whether you want to send customers directly to your final URL while click measurement runs in the background. */
         const AdClickParallelTracking = 'AdClickParallelTracking';
+
+        /** Used to get or set the account's Final URL Suffix. */
+        const FinalUrlSuffix = 'FinalUrlSuffix';
     }
 
 }

--- a/src/V12/CampaignManagement/ActionAdExtension.php
+++ b/src/V12/CampaignManagement/ActionAdExtension.php
@@ -13,7 +13,7 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
     final class ActionAdExtension extends AdExtension
     {
         /**
-         * The text you choose here is what is displayed on your call-to-action button.
+         * The action type that you choose here, as well as the Language that you set, determines the text that is displayed on your call-to-action button.
          * @var ActionAdExtensionActionType
          */
         public $ActionType;
@@ -23,6 +23,12 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
          * @var string[]
          */
         public $FinalMobileUrls;
+
+        /**
+         * The final URL suffix can include tracking parameters that will be appended to the end of your landing page URL.
+         * @var string
+         */
+        public $FinalUrlSuffix;
 
         /**
          * This is the link to your specific web page or form that corresponds to the action text.

--- a/src/V12/CampaignManagement/Ad.php
+++ b/src/V12/CampaignManagement/Ad.php
@@ -52,6 +52,12 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
         public $FinalMobileUrls;
 
         /**
+         * The final URL suffix can include tracking parameters that will be appended to the end of your landing page URL.
+         * @var string
+         */
+        public $FinalUrlSuffix;
+
+        /**
          * The last or final URL where a user is ultimately taken, whether or not the click to final URL path included any redirects.
          * @var string[]
          */

--- a/src/V12/CampaignManagement/AdAdditionalField.php
+++ b/src/V12/CampaignManagement/AdAdditionalField.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
 
 {
     /**
-     * Defines a list of optional Ad properties that you can request when calling GetAdsByAdGroupId, GetAdsByEditorialStatus, and GetAdsByIds.
+     * Defines a list of optional ad properties that you can request when calling GetAdsByAdGroupId, GetAdsByEditorialStatus, and GetAdsByIds.
      * @link https://docs.microsoft.com/en-us/bingads/campaign-management-service/adadditionalfield?view=bingads-12 AdAdditionalField Value Set
      * 
      * @used-by GetAdsByAdGroupIdRequest
@@ -21,6 +21,9 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
 
         /** Request that the Images element be included within each returned ResponsiveAd object. */
         const Images = 'Images';
+
+        /** Request that the FinalUrlSuffix element be included within each returned Ad object. */
+        const FinalUrlSuffix = 'FinalUrlSuffix';
     }
 
 }

--- a/src/V12/CampaignManagement/AdExtensionAdditionalField.php
+++ b/src/V12/CampaignManagement/AdExtensionAdditionalField.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Microsoft\BingAds\V12\CampaignManagement;
+
+{
+    /**
+     * Defines a list of optional ad extension properties that you can request when calling GetAdExtensionsAssociations and GetAdExtensionsByIds.
+     * @link https://docs.microsoft.com/en-us/bingads/campaign-management-service/adextensionadditionalfield?view=bingads-12 AdExtensionAdditionalField Value Set
+     * 
+     * @used-by GetAdExtensionsAssociationsRequest
+     * @used-by GetAdExtensionsByIdsRequest
+     */
+    final class AdExtensionAdditionalField
+    {
+        /** Request that the FinalUrlSuffix element be included within each returned ActionAdExtension, AppAdExtension, ImageAdExtension, PriceAdExtension, and SitelinkAdExtension object. */
+        const FinalUrlSuffix = 'FinalUrlSuffix';
+    }
+
+}

--- a/src/V12/CampaignManagement/AdGroup.php
+++ b/src/V12/CampaignManagement/AdGroup.php
@@ -55,6 +55,12 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
         public $EndDate;
 
         /**
+         * The final URL suffix can include tracking parameters that will be appended to the end of your landing page URL.
+         * @var string
+         */
+        public $FinalUrlSuffix;
+
+        /**
          * The list of key and value strings for forward compatibility to avoid otherwise breaking changes when new elements are added in the current API version.
          * @var KeyValuePairOfstringstring[]
          */

--- a/src/V12/CampaignManagement/AdGroupAdditionalField.php
+++ b/src/V12/CampaignManagement/AdGroupAdditionalField.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Microsoft\BingAds\V12\CampaignManagement;
+
+{
+    /**
+     * Defines a list of optional ad group properties that you can request when calling GetAdGroupsByCampaignId and GetAdGroupsByIds.
+     * @link https://docs.microsoft.com/en-us/bingads/campaign-management-service/adgroupadditionalfield?view=bingads-12 AdGroupAdditionalField Value Set
+     * 
+     * @used-by GetAdGroupsByCampaignIdRequest
+     * @used-by GetAdGroupsByIdsRequest
+     */
+    final class AdGroupAdditionalField
+    {
+        /** Request that the FinalUrlSuffix element be included within each returned AdGroup object. */
+        const FinalUrlSuffix = 'FinalUrlSuffix';
+    }
+
+}

--- a/src/V12/CampaignManagement/AdGroupCriterionAdditionalField.php
+++ b/src/V12/CampaignManagement/AdGroupCriterionAdditionalField.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Microsoft\BingAds\V12\CampaignManagement;
+
+{
+    /**
+     * Defines a list of optional ad group criterion properties that you can request when calling GetAdGroupCriterionsByIds.
+     * @link https://docs.microsoft.com/en-us/bingads/campaign-management-service/adgroupcriterionadditionalfield?view=bingads-12 AdGroupCriterionAdditionalField Value Set
+     * 
+     * @used-by GetAdGroupCriterionsByIdsRequest
+     */
+    final class AdGroupCriterionAdditionalField
+    {
+        /** Request that the FinalUrlSuffix element be included within each returned BiddableAdGroupCriterion object. */
+        const FinalUrlSuffix = 'FinalUrlSuffix';
+    }
+
+}

--- a/src/V12/CampaignManagement/AgeRange.php
+++ b/src/V12/CampaignManagement/AgeRange.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
 
 {
     /**
-     * Defines the possible age range values that you can use to target ads to People.
+     * Defines the possible age range values that you can use to target ads to people.
      * @link https://docs.microsoft.com/en-us/bingads/campaign-management-service/agerange?view=bingads-12 AgeRange Value Set
      * 
      * @used-by AgeCriterion

--- a/src/V12/CampaignManagement/AppAdExtension.php
+++ b/src/V12/CampaignManagement/AppAdExtension.php
@@ -50,6 +50,12 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
 
         /**
          * Reserved for future use.
+         * @var string
+         */
+        public $FinalUrlSuffix;
+
+        /**
+         * Reserved for future use.
          * @var string[]
          */
         public $FinalUrls;

--- a/src/V12/CampaignManagement/BiddableAdGroupCriterion.php
+++ b/src/V12/CampaignManagement/BiddableAdGroupCriterion.php
@@ -45,6 +45,12 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
         public $FinalMobileUrls;
 
         /**
+         * The final URL suffix can include tracking parameters that will be appended to the end of your landing page URL.
+         * @var string
+         */
+        public $FinalUrlSuffix;
+
+        /**
          * Reserved for future use.
          * @var string[]
          */

--- a/src/V12/CampaignManagement/Campaign.php
+++ b/src/V12/CampaignManagement/Campaign.php
@@ -58,6 +58,12 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
         public $ExperimentId;
 
         /**
+         * The final URL suffix can include tracking parameters that will be appended to the end of your landing page URL.
+         * @var string
+         */
+        public $FinalUrlSuffix;
+
+        /**
          * The list of key and value strings for forward compatibility to avoid otherwise breaking changes when new elements are added in the current API version.
          * @var KeyValuePairOfstringstring[]
          */

--- a/src/V12/CampaignManagement/CampaignAdditionalField.php
+++ b/src/V12/CampaignManagement/CampaignAdditionalField.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
 
 {
     /**
-     * Defines a list of optional Campaign properties that you can request when calling GetCampaignsByAccountId and GetCampaignsByIds.
+     * Defines a list of optional campaign properties that you can request when calling GetCampaignsByAccountId and GetCampaignsByIds.
      * @link https://docs.microsoft.com/en-us/bingads/campaign-management-service/campaignadditionalfield?view=bingads-12 CampaignAdditionalField Value Set
      * 
      * @used-by GetCampaignsByAccountIdRequest
@@ -14,6 +14,9 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
     {
         /** Request that the ExperimentId element be included within each returned Campaign object. */
         const ExperimentId = 'ExperimentId';
+
+        /** Request that the FinalUrlSuffix element be included within each returned Campaign object. */
+        const FinalUrlSuffix = 'FinalUrlSuffix';
     }
 
 }

--- a/src/V12/CampaignManagement/CampaignCriterionType.php
+++ b/src/V12/CampaignManagement/CampaignCriterionType.php
@@ -44,6 +44,18 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
         /** The campaign criterion is a location intent criterion. */
         const LocationIntent = 'LocationIntent';
 
+        /** The campaign criterion is an audience criterion. */
+        const Audience = 'Audience';
+
+        /** The campaign criterion is a custom audience association. */
+        const CustomAudience = 'CustomAudience';
+
+        /** The campaign criterion is an in-market audience association. */
+        const InMarketAudience = 'InMarketAudience';
+
+        /** The campaign criterion is a remarketing list association. */
+        const RemarketingList = 'RemarketingList';
+
         /** The campaign criterion is a company name profile criterion. */
         const CompanyName = 'CompanyName';
 
@@ -52,6 +64,12 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
 
         /** The campaign criterion is an industry profile criterion. */
         const Industry = 'Industry';
+
+        /** The campaign criterion is product audience association. */
+        const ProductAudience = 'ProductAudience';
+
+        /** The campaign criterion is a similar remarketing list association. */
+        const SimilarRemarketingList = 'SimilarRemarketingList';
     }
 
 }

--- a/src/V12/CampaignManagement/GenderType.php
+++ b/src/V12/CampaignManagement/GenderType.php
@@ -14,10 +14,10 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
         /** The gender is not known. */
         const Unknown = 'Unknown';
 
-        /** The gender is male. */
+        /** The gender is identified as male. */
         const Male = 'Male';
 
-        /** The gender is female. */
+        /** The gender is identified as female. */
         const Female = 'Female';
     }
 

--- a/src/V12/CampaignManagement/GetAdExtensionsAssociationsRequest.php
+++ b/src/V12/CampaignManagement/GetAdExtensionsAssociationsRequest.php
@@ -9,6 +9,7 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
      * 
      * @uses AdExtensionsTypeFilter
      * @uses AssociationType
+     * @uses AdExtensionAdditionalField
      * @used-by BingAdsCampaignManagementService::GetAdExtensionsAssociations
      */
     final class GetAdExtensionsAssociationsRequest
@@ -36,5 +37,11 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
          * @var integer[]
          */
         public $EntityIds;
+
+        /**
+         * The list of additional properties that you want included within each returned ad extension.
+         * @var AdExtensionAdditionalField
+         */
+        public $ReturnAdditionalFields;
     }
 }

--- a/src/V12/CampaignManagement/GetAdExtensionsByIdsRequest.php
+++ b/src/V12/CampaignManagement/GetAdExtensionsByIdsRequest.php
@@ -8,6 +8,7 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
      * @link https://docs.microsoft.com/en-us/bingads/campaign-management-service/getadextensionsbyids?view=bingads-12 GetAdExtensionsByIds Request Object
      * 
      * @uses AdExtensionsTypeFilter
+     * @uses AdExtensionAdditionalField
      * @used-by BingAdsCampaignManagementService::GetAdExtensionsByIds
      */
     final class GetAdExtensionsByIdsRequest
@@ -29,5 +30,11 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
          * @var AdExtensionsTypeFilter
          */
         public $AdExtensionType;
+
+        /**
+         * The list of additional properties that you want included within each returned ad extension.
+         * @var AdExtensionAdditionalField
+         */
+        public $ReturnAdditionalFields;
     }
 }

--- a/src/V12/CampaignManagement/GetAdGroupCriterionsByIdsRequest.php
+++ b/src/V12/CampaignManagement/GetAdGroupCriterionsByIdsRequest.php
@@ -8,6 +8,7 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
      * @link https://docs.microsoft.com/en-us/bingads/campaign-management-service/getadgroupcriterionsbyids?view=bingads-12 GetAdGroupCriterionsByIds Request Object
      * 
      * @uses AdGroupCriterionType
+     * @uses AdGroupCriterionAdditionalField
      * @used-by BingAdsCampaignManagementService::GetAdGroupCriterionsByIds
      */
     final class GetAdGroupCriterionsByIdsRequest
@@ -29,5 +30,11 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
          * @var AdGroupCriterionType
          */
         public $CriterionType;
+
+        /**
+         * The list of additional properties that you want included within each returned ad group criterion.
+         * @var AdGroupCriterionAdditionalField
+         */
+        public $ReturnAdditionalFields;
     }
 }

--- a/src/V12/CampaignManagement/GetAdGroupsByCampaignIdRequest.php
+++ b/src/V12/CampaignManagement/GetAdGroupsByCampaignIdRequest.php
@@ -7,6 +7,7 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
      * Gets the ad groups within the specified campaign.
      * @link https://docs.microsoft.com/en-us/bingads/campaign-management-service/getadgroupsbycampaignid?view=bingads-12 GetAdGroupsByCampaignId Request Object
      * 
+     * @uses AdGroupAdditionalField
      * @used-by BingAdsCampaignManagementService::GetAdGroupsByCampaignId
      */
     final class GetAdGroupsByCampaignIdRequest
@@ -16,5 +17,11 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
          * @var integer
          */
         public $CampaignId;
+
+        /**
+         * The list of additional properties that you want included within each returned ad group.
+         * @var AdGroupAdditionalField
+         */
+        public $ReturnAdditionalFields;
     }
 }

--- a/src/V12/CampaignManagement/GetAdGroupsByIdsRequest.php
+++ b/src/V12/CampaignManagement/GetAdGroupsByIdsRequest.php
@@ -7,6 +7,7 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
      * Gets the specified ad groups within the specified campaign.
      * @link https://docs.microsoft.com/en-us/bingads/campaign-management-service/getadgroupsbyids?view=bingads-12 GetAdGroupsByIds Request Object
      * 
+     * @uses AdGroupAdditionalField
      * @used-by BingAdsCampaignManagementService::GetAdGroupsByIds
      */
     final class GetAdGroupsByIdsRequest
@@ -22,5 +23,11 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
          * @var integer[]
          */
         public $AdGroupIds;
+
+        /**
+         * The list of additional properties that you want included within each returned ad group.
+         * @var AdGroupAdditionalField
+         */
+        public $ReturnAdditionalFields;
     }
 }

--- a/src/V12/CampaignManagement/GetAdsByAdGroupIdRequest.php
+++ b/src/V12/CampaignManagement/GetAdsByAdGroupIdRequest.php
@@ -26,7 +26,7 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
         public $AdTypes;
 
         /**
-         * The list of additional properties that you want included within each returned Ad object.
+         * The list of additional properties that you want included within each returned ad.
          * @var AdAdditionalField
          */
         public $ReturnAdditionalFields;

--- a/src/V12/CampaignManagement/GetAdsByEditorialStatusRequest.php
+++ b/src/V12/CampaignManagement/GetAdsByEditorialStatusRequest.php
@@ -33,7 +33,7 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
         public $AdTypes;
 
         /**
-         * The list of additional properties that you want included within each returned Ad object.
+         * The list of additional properties that you want included within each returned ad.
          * @var AdAdditionalField
          */
         public $ReturnAdditionalFields;

--- a/src/V12/CampaignManagement/GetAdsByIdsRequest.php
+++ b/src/V12/CampaignManagement/GetAdsByIdsRequest.php
@@ -32,7 +32,7 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
         public $AdTypes;
 
         /**
-         * The list of additional properties that you want included within each returned Ad object.
+         * The list of additional properties that you want included within each returned ad.
          * @var AdAdditionalField
          */
         public $ReturnAdditionalFields;

--- a/src/V12/CampaignManagement/GetKeywordsByAdGroupIdRequest.php
+++ b/src/V12/CampaignManagement/GetKeywordsByAdGroupIdRequest.php
@@ -7,6 +7,7 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
      * Gets the keywords within an ad group.
      * @link https://docs.microsoft.com/en-us/bingads/campaign-management-service/getkeywordsbyadgroupid?view=bingads-12 GetKeywordsByAdGroupId Request Object
      * 
+     * @uses KeywordAdditionalField
      * @used-by BingAdsCampaignManagementService::GetKeywordsByAdGroupId
      */
     final class GetKeywordsByAdGroupIdRequest
@@ -16,5 +17,11 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
          * @var integer
          */
         public $AdGroupId;
+
+        /**
+         * The list of additional properties that you want included within each returned keyword.
+         * @var KeywordAdditionalField
+         */
+        public $ReturnAdditionalFields;
     }
 }

--- a/src/V12/CampaignManagement/GetKeywordsByEditorialStatusRequest.php
+++ b/src/V12/CampaignManagement/GetKeywordsByEditorialStatusRequest.php
@@ -8,6 +8,7 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
      * @link https://docs.microsoft.com/en-us/bingads/campaign-management-service/getkeywordsbyeditorialstatus?view=bingads-12 GetKeywordsByEditorialStatus Request Object
      * 
      * @uses KeywordEditorialStatus
+     * @uses KeywordAdditionalField
      * @used-by BingAdsCampaignManagementService::GetKeywordsByEditorialStatus
      */
     final class GetKeywordsByEditorialStatusRequest
@@ -23,5 +24,11 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
          * @var KeywordEditorialStatus
          */
         public $EditorialStatus;
+
+        /**
+         * The list of additional properties that you want included within each returned keyword.
+         * @var KeywordAdditionalField
+         */
+        public $ReturnAdditionalFields;
     }
 }

--- a/src/V12/CampaignManagement/GetKeywordsByIdsRequest.php
+++ b/src/V12/CampaignManagement/GetKeywordsByIdsRequest.php
@@ -7,6 +7,7 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
      * Retrieves the specified keywords.
      * @link https://docs.microsoft.com/en-us/bingads/campaign-management-service/getkeywordsbyids?view=bingads-12 GetKeywordsByIds Request Object
      * 
+     * @uses KeywordAdditionalField
      * @used-by BingAdsCampaignManagementService::GetKeywordsByIds
      */
     final class GetKeywordsByIdsRequest
@@ -22,5 +23,11 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
          * @var integer[]
          */
         public $KeywordIds;
+
+        /**
+         * The list of additional properties that you want included within each returned keyword.
+         * @var KeywordAdditionalField
+         */
+        public $ReturnAdditionalFields;
     }
 }

--- a/src/V12/CampaignManagement/ImageAdExtension.php
+++ b/src/V12/CampaignManagement/ImageAdExtension.php
@@ -31,19 +31,25 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
         public $DestinationUrl;
 
         /**
-         * Reserved for future use.
+         * Not supported for image ad extensions.
          * @var AppUrl[]
          */
         public $FinalAppUrls;
 
         /**
-         * Reserved for future use.
+         * Not supported for image ad extensions.
          * @var string[]
          */
         public $FinalMobileUrls;
 
         /**
-         * Reserved for future use.
+         * Not supported for image ad extensions.
+         * @var string
+         */
+        public $FinalUrlSuffix;
+
+        /**
+         * Not supported for image ad extensions.
          * @var string[]
          */
         public $FinalUrls;
@@ -55,13 +61,13 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
         public $ImageMediaIds;
 
         /**
-         * Reserved for future use.
+         * Not supported for image ad extensions.
          * @var string
          */
         public $TrackingUrlTemplate;
 
         /**
-         * Reserved for future use.
+         * Not supported for image ad extensions.
          * @var CustomParameters
          */
         public $UrlCustomParameters;

--- a/src/V12/CampaignManagement/Keyword.php
+++ b/src/V12/CampaignManagement/Keyword.php
@@ -60,6 +60,12 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
         public $FinalMobileUrls;
 
         /**
+         * The final URL suffix can include tracking parameters that will be appended to the end of your landing page URL.
+         * @var string
+         */
+        public $FinalUrlSuffix;
+
+        /**
          * The landing page URL.
          * @var string[]
          */

--- a/src/V12/CampaignManagement/KeywordAdditionalField.php
+++ b/src/V12/CampaignManagement/KeywordAdditionalField.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Microsoft\BingAds\V12\CampaignManagement;
+
+{
+    /**
+     * Defines a list of optional keyword properties that you can request when calling GetKeywordsByAdGroupId, GetKeywordsByEditorialStatus, and GetKeywordsByIds.
+     * @link https://docs.microsoft.com/en-us/bingads/campaign-management-service/keywordadditionalfield?view=bingads-12 KeywordAdditionalField Value Set
+     * 
+     * @used-by GetKeywordsByAdGroupIdRequest
+     * @used-by GetKeywordsByEditorialStatusRequest
+     * @used-by GetKeywordsByIdsRequest
+     */
+    final class KeywordAdditionalField
+    {
+        /** Request that the FinalUrlSuffix element be included within each returned Keyword object. */
+        const FinalUrlSuffix = 'FinalUrlSuffix';
+    }
+
+}

--- a/src/V12/CampaignManagement/PriceAdExtension.php
+++ b/src/V12/CampaignManagement/PriceAdExtension.php
@@ -14,6 +14,12 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
     final class PriceAdExtension extends AdExtension
     {
         /**
+         * The final URL suffix can include tracking parameters that will be appended to the end of your landing page URL.
+         * @var string
+         */
+        public $FinalUrlSuffix;
+
+        /**
          * The language for the ad copy of your price ad extension.
          * @var string
          */

--- a/src/V12/CampaignManagement/SitelinkAdExtension.php
+++ b/src/V12/CampaignManagement/SitelinkAdExtension.php
@@ -49,6 +49,12 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
         public $FinalMobileUrls;
 
         /**
+         * The final URL suffix can include tracking parameters that will be appended to the end of your landing page URL.
+         * @var string
+         */
+        public $FinalUrlSuffix;
+
+        /**
          * The landing page URL.
          * @var string[]
          */

--- a/src/V12/CustomerBilling/InsertionOrder.php
+++ b/src/V12/CustomerBilling/InsertionOrder.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V12\CustomerBilling;
 
 {
     /**
-     * Defines an insertion order.
+     * An insertion order is a contract that establishes the maximum amount you will spend on your account over a specified period of time.
      * @link https://docs.microsoft.com/en-us/bingads/customer-billing-service/insertionorder?view=bingads-12 InsertionOrder Data Object
      * 
      * @uses InsertionOrderStatus

--- a/src/V12/CustomerManagement/SendUserInvitationRequest.php
+++ b/src/V12/CustomerManagement/SendUserInvitationRequest.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V12\CustomerManagement;
 
 {
     /**
-     * Sends an invitation for  a Microsoft account user to manage one or more Bing Ads customer accounts.
+     * Sends an email invitation for someone to manage your Bing Ads accounts.
      * @link https://docs.microsoft.com/en-us/bingads/customer-management-service/senduserinvitation?view=bingads-12 SendUserInvitation Request Object
      * 
      * @uses UserInvitation

--- a/src/V12/CustomerManagement/SendUserInvitationResponse.php
+++ b/src/V12/CustomerManagement/SendUserInvitationResponse.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V12\CustomerManagement;
 
 {
     /**
-     * Sends an invitation for  a Microsoft account user to manage one or more Bing Ads customer accounts.
+     * Sends an email invitation for someone to manage your Bing Ads accounts.
      * @link https://docs.microsoft.com/en-us/bingads/customer-management-service/senduserinvitation?view=bingads-12 SendUserInvitation Response Object
      * 
      * @used-by BingAdsCustomerManagementService::SendUserInvitation

--- a/src/V12/Reporting/AccountReportScope.php
+++ b/src/V12/Reporting/AccountReportScope.php
@@ -12,7 +12,7 @@ namespace Microsoft\BingAds\V12\Reporting;
     final class AccountReportScope
     {
         /**
-         * An array of a maximum of 1,000 account identifiers that identifies the account data to include in the report.
+         * A list of up to 1,000 account identifiers to include in the report.
          * @var integer[]
          */
         public $AccountIds;

--- a/src/V12/Reporting/AccountThroughAdGroupReportScope.php
+++ b/src/V12/Reporting/AccountThroughAdGroupReportScope.php
@@ -43,19 +43,19 @@ namespace Microsoft\BingAds\V12\Reporting;
     final class AccountThroughAdGroupReportScope
     {
         /**
-         * An array of account identifiers that identifies the account data to include in the report.
+         * A list of up to 1,000 account identifiers to include in the report.
          * @var integer[]
          */
         public $AccountIds;
 
         /**
-         * An array of AdGroupReportScope objects that identifies the ad group data to include in the report.
+         * A list of up to 300 ad groups to include in the report.
          * @var AdGroupReportScope[]
          */
         public $AdGroups;
 
         /**
-         * An array of CampaignReportScope objects that identifies the campaign data to include in the report.
+         * A list of up to 300 campaigns to include in the report.
          * @var CampaignReportScope[]
          */
         public $Campaigns;

--- a/src/V12/Reporting/AccountThroughCampaignReportScope.php
+++ b/src/V12/Reporting/AccountThroughCampaignReportScope.php
@@ -14,13 +14,13 @@ namespace Microsoft\BingAds\V12\Reporting;
     final class AccountThroughCampaignReportScope
     {
         /**
-         * An array of account identifiers that identifies the account data to include in the report.
+         * A list of up to 1,000 account identifiers to include in the report.
          * @var integer[]
          */
         public $AccountIds;
 
         /**
-         * An array of CampaignReportScope objects that identifies the campaign data to include in the report.
+         * A list of up to 300 campaigns to include in the report.
          * @var CampaignReportScope[]
          */
         public $Campaigns;

--- a/src/V12/Reporting/AdGroupPerformanceReportColumn.php
+++ b/src/V12/Reporting/AdGroupPerformanceReportColumn.php
@@ -199,6 +199,9 @@ namespace Microsoft\BingAds\V12\Reporting;
 
         /** The number of times your ad is shown in the top position as a percentage of the total available impressions in the market you were targeting. */
         const AbsoluteTopImpressionSharePercent = 'AbsoluteTopImpressionSharePercent';
+
+        /** The final URL suffix can include tracking parameters that will be appended to the end of your landing page URL. */
+        const FinalUrlSuffix = 'FinalUrlSuffix';
     }
 
 }

--- a/src/V12/Reporting/AdGroupPerformanceReportColumn.php
+++ b/src/V12/Reporting/AdGroupPerformanceReportColumn.php
@@ -202,6 +202,9 @@ namespace Microsoft\BingAds\V12\Reporting;
 
         /** The final URL suffix can include tracking parameters that will be appended to the end of your landing page URL. */
         const FinalUrlSuffix = 'FinalUrlSuffix';
+
+        /** The campaign type. */
+        const CampaignType = 'CampaignType';
     }
 
 }

--- a/src/V12/Reporting/AdPerformanceReportColumn.php
+++ b/src/V12/Reporting/AdPerformanceReportColumn.php
@@ -187,6 +187,9 @@ namespace Microsoft\BingAds\V12\Reporting;
 
         /** The customer name. */
         const CustomerName = 'CustomerName';
+
+        /** The campaign type. */
+        const CampaignType = 'CampaignType';
     }
 
 }

--- a/src/V12/Reporting/AgeGenderAudienceReportRequest.php
+++ b/src/V12/Reporting/AgeGenderAudienceReportRequest.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V12\Reporting;
 
 {
     /**
-     * Defines an age and gender audience report request for Audience campaigns.
+     * Defines an age and gender audience report request.
      * @link https://docs.microsoft.com/en-us/bingads/reporting-service/agegenderaudiencereportrequest?view=bingads-12 AgeGenderAudienceReportRequest Data Object
      * 
      * @uses ReportAggregation

--- a/src/V12/Reporting/CampaignPerformanceReportColumn.php
+++ b/src/V12/Reporting/CampaignPerformanceReportColumn.php
@@ -223,6 +223,9 @@ namespace Microsoft\BingAds\V12\Reporting;
 
         /** The final URL suffix can include tracking parameters that will be appended to the end of your landing page URL. */
         const FinalUrlSuffix = 'FinalUrlSuffix';
+
+        /** The campaign type. */
+        const CampaignType = 'CampaignType';
     }
 
 }

--- a/src/V12/Reporting/CampaignPerformanceReportColumn.php
+++ b/src/V12/Reporting/CampaignPerformanceReportColumn.php
@@ -220,6 +220,9 @@ namespace Microsoft\BingAds\V12\Reporting;
 
         /** The number of times your ad is shown in the top position as a percentage of the total available impressions in the market you were targeting. */
         const AbsoluteTopImpressionSharePercent = 'AbsoluteTopImpressionSharePercent';
+
+        /** The final URL suffix can include tracking parameters that will be appended to the end of your landing page URL. */
+        const FinalUrlSuffix = 'FinalUrlSuffix';
     }
 
 }

--- a/src/V12/Reporting/DestinationUrlPerformanceReportColumn.php
+++ b/src/V12/Reporting/DestinationUrlPerformanceReportColumn.php
@@ -145,6 +145,9 @@ namespace Microsoft\BingAds\V12\Reporting;
 
         /** The customer name. */
         const CustomerName = 'CustomerName';
+
+        /** The final URL suffix can include tracking parameters that will be appended to the end of your landing page URL. */
+        const FinalUrlSuffix = 'FinalUrlSuffix';
     }
 
 }

--- a/src/V12/Reporting/KeywordPerformanceReportColumn.php
+++ b/src/V12/Reporting/KeywordPerformanceReportColumn.php
@@ -194,6 +194,9 @@ namespace Microsoft\BingAds\V12\Reporting;
 
         /** Based on your campaign performance and marketplace dynamics, this estimate is the bid amount that Bing Ads calculates for your ad to be placed on the first page in the search results. */
         const FirstPageBid = 'FirstPageBid';
+
+        /** The final URL suffix can include tracking parameters that will be appended to the end of your landing page URL. */
+        const FinalUrlSuffix = 'FinalUrlSuffix';
     }
 
 }

--- a/src/V12/Reporting/ProfessionalDemographicsAudienceReportFilter.php
+++ b/src/V12/Reporting/ProfessionalDemographicsAudienceReportFilter.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V12\Reporting;
 
 {
     /**
-     * Defines the criteria to use to filter the professional demographics audience report for Audience campaigns.
+     * Defines the criteria to use to filter the professional demographics audience report.
      * @link https://docs.microsoft.com/en-us/bingads/reporting-service/professionaldemographicsaudiencereportfilter?view=bingads-12 ProfessionalDemographicsAudienceReportFilter Data Object
      * 
      * @uses AccountStatusReportFilter

--- a/src/V12/Reporting/ProfessionalDemographicsAudienceReportRequest.php
+++ b/src/V12/Reporting/ProfessionalDemographicsAudienceReportRequest.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V12\Reporting;
 
 {
     /**
-     * Defines a professional demographics audience report request for Audience campaigns.
+     * Defines a professional demographics audience report request.
      * @link https://docs.microsoft.com/en-us/bingads/reporting-service/professionaldemographicsaudiencereportrequest?view=bingads-12 ProfessionalDemographicsAudienceReportRequest Data Object
      * 
      * @uses ReportAggregation

--- a/src/V12/Reporting/ReportRequest.php
+++ b/src/V12/Reporting/ReportRequest.php
@@ -20,7 +20,7 @@ namespace Microsoft\BingAds\V12\Reporting;
         public $ExcludeColumnHeaders;
 
         /**
-         * Determines whether or not the downloaded report should contain footer metadata such as Microsoft copyright (@2018 Microsoft Corporation.
+         * Determines whether or not the downloaded report should contain footer metadata such as Microsoft copyright (@2019 Microsoft Corporation.
          * @var boolean
          */
         public $ExcludeReportFooter;

--- a/src/V12/Reporting/SearchQueryPerformanceReportColumn.php
+++ b/src/V12/Reporting/SearchQueryPerformanceReportColumn.php
@@ -137,7 +137,7 @@ namespace Microsoft\BingAds\V12\Reporting;
         /** The keyword status. */
         const KeywordStatus = 'KeywordStatus';
 
-        /** The type of campaign. */
+        /** The campaign type. */
         const CampaignType = 'CampaignType';
 
         /** The Bing Ads assigned identifier of a customer. */


### PR DESCRIPTION
The minimum required PHP version in [composer.json](https://github.com/BingAds/BingAds-PHP-SDK/blob/master/composer.json) is updated to 7.1. You should upgrade to the latest (7.3) if possible. Versions 5.6 and 7.0 are [no longer supported](http://php.net/supported-versions.php) by the PHP development team. For more details see [Migrating from PHP 5.6.x to PHP 7.0.x](http://php.net/manual/en/migration70.php) and [Migrating from PHP 7.0.x to PHP 7.1.x](http://php.net/manual/en/migration71.php). 