### PR TITLE
update proxies add user agent header

### DIFF
--- a/samples/V12/AuthHelper.php
+++ b/samples/V12/AuthHelper.php
@@ -43,7 +43,7 @@ final class AuthHelper {
     const DeveloperToken = 'BBD37VB98'; // For sandbox use BBD37VB98
     const ApiEnvironment = ApiEnvironment::Sandbox;
     const OAuthRefreshTokenPath = 'refresh.txt';
-    const ClientId = 'ClientIdGoesHere'; 
+    const ClientId = 'db41b09d-6e50-4f4a-90ac-5a99caefb52f';  // For sandbox use db41b09d-6e50-4f4a-90ac-5a99caefb52f
 
     const CampaignTypes = 
         CampaignType::Audience . ' ' . 

--- a/samples/V12/CampaignManagementExampleHelper.php
+++ b/samples/V12/CampaignManagementExampleHelper.php
@@ -90,6 +90,7 @@ use Microsoft\BingAds\V12\CampaignManagement\GetSharedEntitiesByAccountIdRequest
 use Microsoft\BingAds\V12\CampaignManagement\GetSharedEntityAssociationsByEntityIdsRequest;
 use Microsoft\BingAds\V12\CampaignManagement\GetSharedEntityAssociationsBySharedEntityIdsRequest;
 use Microsoft\BingAds\V12\CampaignManagement\GetUetTagsByIdsRequest;
+use Microsoft\BingAds\V12\CampaignManagement\SearchCompaniesRequest;
 use Microsoft\BingAds\V12\CampaignManagement\SetAccountPropertiesRequest;
 use Microsoft\BingAds\V12\CampaignManagement\SetAdExtensionsAssociationsRequest;
 use Microsoft\BingAds\V12\CampaignManagement\SetLabelAssociationsRequest;
@@ -1257,6 +1258,20 @@ final class CampaignManagementExampleHelper {
         $request->TagIds = $tagIds;
 
         return $GLOBALS['CampaignManagementProxy']->GetService()->GetUetTagsByIds($request);
+    }
+    static function SearchCompanies(
+        $companyNameFilter,
+        $languageLocale)
+    {
+        $GLOBALS['CampaignManagementProxy']->SetAuthorizationData($GLOBALS['AuthorizationData']);
+        $GLOBALS['Proxy'] = $GLOBALS['CampaignManagementProxy'];
+
+        $request = new SearchCompaniesRequest();
+
+        $request->CompanyNameFilter = $companyNameFilter;
+        $request->LanguageLocale = $languageLocale;
+
+        return $GLOBALS['CampaignManagementProxy']->GetService()->SearchCompanies($request);
     }
     static function SetAccountProperties(
         $accountProperties)
@@ -2781,6 +2796,29 @@ final class CampaignManagementExampleHelper {
         foreach ($dataObjects->CampaignNegativeSites as $dataObject)
         {
             self::OutputCampaignNegativeSites($dataObject);
+        }
+    }
+    static function OutputCompany($dataObject)
+    {
+        if (!empty($dataObject))
+        {
+            self::OutputStatusMessage("* * * Begin OutputCompany * * *");
+            self::OutputStatusMessage(sprintf("LogoUrl: %s", $dataObject->LogoUrl));
+            self::OutputStatusMessage(sprintf("Name: %s", $dataObject->Name));
+            self::OutputStatusMessage(sprintf("ProfileId: %s", $dataObject->ProfileId));
+            self::OutputStatusMessage(sprintf("Status: %s", $dataObject->Status));
+            self::OutputStatusMessage("* * * End OutputCompany * * *");
+        }
+    }
+    static function OutputArrayOfCompany($dataObjects)
+    {
+        if(count((array)$dataObjects) == 0 || !isset($dataObjects->Company))
+        {
+            return;
+        }
+        foreach ($dataObjects->Company as $dataObject)
+        {
+            self::OutputCompany($dataObject);
         }
     }
     static function OutputConversionGoal($dataObject)

--- a/samples/V13/AuthHelper.php
+++ b/samples/V13/AuthHelper.php
@@ -43,7 +43,7 @@ final class AuthHelper {
     const DeveloperToken = 'BBD37VB98'; // For sandbox use BBD37VB98
     const ApiEnvironment = ApiEnvironment::Sandbox;
     const OAuthRefreshTokenPath = 'refresh.txt';
-    const ClientId = 'ClientIdGoesHere'; 
+    const ClientId = 'db41b09d-6e50-4f4a-90ac-5a99caefb52f';  // For sandbox use db41b09d-6e50-4f4a-90ac-5a99caefb52f
 
     const CampaignTypes = 
         CampaignType::Audience . ' ' . 

--- a/samples/V13/CampaignManagementExampleHelper.php
+++ b/samples/V13/CampaignManagementExampleHelper.php
@@ -90,6 +90,7 @@ use Microsoft\BingAds\V13\CampaignManagement\GetSharedEntitiesByAccountIdRequest
 use Microsoft\BingAds\V13\CampaignManagement\GetSharedEntityAssociationsByEntityIdsRequest;
 use Microsoft\BingAds\V13\CampaignManagement\GetSharedEntityAssociationsBySharedEntityIdsRequest;
 use Microsoft\BingAds\V13\CampaignManagement\GetUetTagsByIdsRequest;
+use Microsoft\BingAds\V13\CampaignManagement\SearchCompaniesRequest;
 use Microsoft\BingAds\V13\CampaignManagement\SetAccountPropertiesRequest;
 use Microsoft\BingAds\V13\CampaignManagement\SetAdExtensionsAssociationsRequest;
 use Microsoft\BingAds\V13\CampaignManagement\SetLabelAssociationsRequest;
@@ -1229,6 +1230,20 @@ final class CampaignManagementExampleHelper {
         $request->TagIds = $tagIds;
 
         return $GLOBALS['CampaignManagementProxy']->GetService()->GetUetTagsByIds($request);
+    }
+    static function SearchCompanies(
+        $companyNameFilter,
+        $languageLocale)
+    {
+        $GLOBALS['CampaignManagementProxy']->SetAuthorizationData($GLOBALS['AuthorizationData']);
+        $GLOBALS['Proxy'] = $GLOBALS['CampaignManagementProxy'];
+
+        $request = new SearchCompaniesRequest();
+
+        $request->CompanyNameFilter = $companyNameFilter;
+        $request->LanguageLocale = $languageLocale;
+
+        return $GLOBALS['CampaignManagementProxy']->GetService()->SearchCompanies($request);
     }
     static function SetAccountProperties(
         $accountProperties)
@@ -2760,6 +2775,29 @@ final class CampaignManagementExampleHelper {
         foreach ($dataObjects->CampaignNegativeSites as $dataObject)
         {
             self::OutputCampaignNegativeSites($dataObject);
+        }
+    }
+    static function OutputCompany($dataObject)
+    {
+        if (!empty($dataObject))
+        {
+            self::OutputStatusMessage("* * * Begin OutputCompany * * *");
+            self::OutputStatusMessage(sprintf("LogoUrl: %s", $dataObject->LogoUrl));
+            self::OutputStatusMessage(sprintf("Name: %s", $dataObject->Name));
+            self::OutputStatusMessage(sprintf("ProfileId: %s", $dataObject->ProfileId));
+            self::OutputStatusMessage(sprintf("Status: %s", $dataObject->Status));
+            self::OutputStatusMessage("* * * End OutputCompany * * *");
+        }
+    }
+    static function OutputArrayOfCompany($dataObjects)
+    {
+        if(count((array)$dataObjects) == 0 || !isset($dataObjects->Company))
+        {
+            return;
+        }
+        foreach ($dataObjects->Company as $dataObject)
+        {
+            self::OutputCompany($dataObject);
         }
     }
     static function OutputConversionGoal($dataObject)

--- a/samples/V13/CustomerManagementExampleHelper.php
+++ b/samples/V13/CustomerManagementExampleHelper.php
@@ -17,6 +17,7 @@ use Microsoft\BingAds\V13\CustomerManagement\DeleteUserRequest;
 use Microsoft\BingAds\V13\CustomerManagement\FindAccountsRequest;
 use Microsoft\BingAds\V13\CustomerManagement\FindAccountsOrCustomersInfoRequest;
 use Microsoft\BingAds\V13\CustomerManagement\GetAccountRequest;
+use Microsoft\BingAds\V13\CustomerManagement\GetAccountPilotFeaturesRequest;
 use Microsoft\BingAds\V13\CustomerManagement\GetAccountsInfoRequest;
 use Microsoft\BingAds\V13\CustomerManagement\GetCustomerRequest;
 use Microsoft\BingAds\V13\CustomerManagement\GetCustomerPilotFeaturesRequest;
@@ -145,6 +146,18 @@ final class CustomerManagementExampleHelper {
         $request->AccountId = $accountId;
 
         return $GLOBALS['CustomerManagementProxy']->GetService()->GetAccount($request);
+    }
+    static function GetAccountPilotFeatures(
+        $accountId)
+    {
+        $GLOBALS['CustomerManagementProxy']->SetAuthorizationData($GLOBALS['AuthorizationData']);
+        $GLOBALS['Proxy'] = $GLOBALS['CustomerManagementProxy'];
+
+        $request = new GetAccountPilotFeaturesRequest();
+
+        $request->AccountId = $accountId;
+
+        return $GLOBALS['CustomerManagementProxy']->GetService()->GetAccountPilotFeatures($request);
     }
     static function GetAccountsInfo(
         $customerId,

--- a/src/Auth/ServiceClient.php
+++ b/src/Auth/ServiceClient.php
@@ -252,6 +252,7 @@ class ServiceClient
 			'features' => SOAP_SINGLE_ELEMENT_ARRAYS,
 			// Disable keep-alive to avoid 'Process open FD table is full'
 			'keep-alive' => FALSE, 
+			'user_agent' => 'BingAdsSDKPHP ' . '12.13.4 ' . PHP_VERSION, 
 
 			/** 
 			 * Map long type to string type. For details, see

--- a/src/V12/CampaignManagement/Company.php
+++ b/src/V12/CampaignManagement/Company.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Microsoft\BingAds\V12\CampaignManagement;
+
+{
+    /**
+     * Defines the profile data for a company.
+     * @link https://docs.microsoft.com/en-us/advertising/campaign-management-service/company?view=bingads-12 Company Data Object
+     * 
+     * @used-by SearchCompaniesResponse
+     */
+    final class Company
+    {
+        /**
+         * The full https path for the company's logo image.
+         * @var string
+         */
+        public $LogoUrl;
+
+        /**
+         * The company name.
+         * @var string
+         */
+        public $Name;
+
+        /**
+         * The company name profile identifier that you can use with ProfileCriterion.
+         * @var integer
+         */
+        public $ProfileId;
+
+        /**
+         * The company name profile status.
+         * @var string
+         */
+        public $Status;
+    }
+
+}

--- a/src/V12/CampaignManagement/GetProfileDataFileUrlRequest.php
+++ b/src/V12/CampaignManagement/GetProfileDataFileUrlRequest.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
 
 {
     /**
-     * Gets a temporary URL that you can use to download company name, industry, or job function profile data.
+     * Gets a temporary URL that you can use to download industry or job function profile data.
      * @link https://docs.microsoft.com/en-us/advertising/campaign-management-service/getprofiledatafileurl?view=bingads-12 GetProfileDataFileUrl Request Object
      * 
      * @uses ProfileType
@@ -19,7 +19,7 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
         public $LanguageLocale;
 
         /**
-         * Determines whether you want company name, industry, or job function profile data.
+         * Determines whether you want industry or job function profile data.
          * @var ProfileType
          */
         public $ProfileType;

--- a/src/V12/CampaignManagement/GetProfileDataFileUrlResponse.php
+++ b/src/V12/CampaignManagement/GetProfileDataFileUrlResponse.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
 
 {
     /**
-     * Gets a temporary URL that you can use to download company name, industry, or job function profile data.
+     * Gets a temporary URL that you can use to download industry or job function profile data.
      * @link https://docs.microsoft.com/en-us/advertising/campaign-management-service/getprofiledatafileurl?view=bingads-12 GetProfileDataFileUrl Response Object
      * 
      * @used-by BingAdsCampaignManagementService::GetProfileDataFileUrl

--- a/src/V12/CampaignManagement/ProfileCriterion.php
+++ b/src/V12/CampaignManagement/ProfileCriterion.php
@@ -12,7 +12,7 @@ namespace Microsoft\BingAds\V12\CampaignManagement;
     final class ProfileCriterion extends Criterion
     {
         /**
-         * The identifier of the audience profile that you want to target.
+         * The identifier of the company name, industry, or job function profile that you want to target.
          * @var integer
          */
         public $ProfileId;

--- a/src/V12/CampaignManagement/SearchCompaniesRequest.php
+++ b/src/V12/CampaignManagement/SearchCompaniesRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Microsoft\BingAds\V12\CampaignManagement;
+
+{
+    /**
+     * Search for profile data by company name.
+     * @link https://docs.microsoft.com/en-us/advertising/campaign-management-service/searchcompanies?view=bingads-12 SearchCompanies Request Object
+     * 
+     * @used-by BingAdsCampaignManagementService::SearchCompanies
+     */
+    final class SearchCompaniesRequest
+    {
+        /**
+         * The company name filter string.
+         * @var string
+         */
+        public $CompanyNameFilter;
+
+        /**
+         * The language and locale of the profile display names.
+         * @var string
+         */
+        public $LanguageLocale;
+    }
+}

--- a/src/V12/CampaignManagement/SearchCompaniesResponse.php
+++ b/src/V12/CampaignManagement/SearchCompaniesResponse.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Microsoft\BingAds\V12\CampaignManagement;
+
+{
+    /**
+     * Search for profile data by company name.
+     * @link https://docs.microsoft.com/en-us/advertising/campaign-management-service/searchcompanies?view=bingads-12 SearchCompanies Response Object
+     * 
+     * @uses Company
+     * @used-by BingAdsCampaignManagementService::SearchCompanies
+     */
+    final class SearchCompaniesResponse
+    {
+        /**
+         * The list of companies that match the requested company name filter.
+         * @var Company[]
+         */
+        public $Companies;
+    }
+}

--- a/src/V12/CustomerManagement/GetCustomerPilotFeaturesRequest.php
+++ b/src/V12/CustomerManagement/GetCustomerPilotFeaturesRequest.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V12\CustomerManagement;
 
 {
     /**
-     * Gets a list of the pilot programs in which the specified customer participates.
+     * Gets a list of the pilot programs that are enabled for all of the customer's accounts.
      * @link https://docs.microsoft.com/en-us/advertising/customer-management-service/getcustomerpilotfeatures?view=bingads-12 GetCustomerPilotFeatures Request Object
      * 
      * @used-by BingAdsCustomerManagementService::GetCustomerPilotFeatures
@@ -12,7 +12,7 @@ namespace Microsoft\BingAds\V12\CustomerManagement;
     final class GetCustomerPilotFeaturesRequest
     {
         /**
-         * The identifier of the customer whose list of pilot programs you want to get.
+         * The identifier of the customer used to get a list of pilot features.
          * @var integer
          */
         public $CustomerId;

--- a/src/V12/CustomerManagement/GetCustomerPilotFeaturesResponse.php
+++ b/src/V12/CustomerManagement/GetCustomerPilotFeaturesResponse.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V12\CustomerManagement;
 
 {
     /**
-     * Gets a list of the pilot programs in which the specified customer participates.
+     * Gets a list of the pilot programs that are enabled for all of the customer's accounts.
      * @link https://docs.microsoft.com/en-us/advertising/customer-management-service/getcustomerpilotfeatures?view=bingads-12 GetCustomerPilotFeatures Response Object
      * 
      * @used-by BingAdsCustomerManagementService::GetCustomerPilotFeatures
@@ -12,7 +12,7 @@ namespace Microsoft\BingAds\V12\CustomerManagement;
     final class GetCustomerPilotFeaturesResponse
     {
         /**
-         * A list of integers that identifies the pilot programs in which the customer participates.
+         * A list of integers that identifies the pilot features that are enabled for all of the customer's accounts.
          * @var integer[]
          */
         public $FeaturePilotFlags;

--- a/src/V12/Reporting/AudiencePerformanceReportColumn.php
+++ b/src/V12/Reporting/AudiencePerformanceReportColumn.php
@@ -41,7 +41,7 @@ namespace Microsoft\BingAds\V12\Reporting;
         /** The audience name. */
         const AudienceName = 'AudienceName';
 
-        /** The status of the association between the ad group and remarketing list, which indicates whether ads are eligible to display. */
+        /** The status of the association between the audience and either an ad group or campaign. */
         const AssociationStatus = 'AssociationStatus';
 
         /** This attribute reflects the current value of your ad group's audience bid adjustment, even if a different bid adjustment value was used when the ad was shown. */
@@ -97,6 +97,9 @@ namespace Microsoft\BingAds\V12\Reporting;
 
         /** The audience type. */
         const AudienceType = 'AudienceType';
+
+        /** The Microsoft Advertising assigned identifier of the association between the audience and either an ad group or campaign. */
+        const AssociationId = 'AssociationId';
     }
 
 }

--- a/src/V12/Reporting/ProfessionalDemographicsAudienceReportColumn.php
+++ b/src/V12/Reporting/ProfessionalDemographicsAudienceReportColumn.php
@@ -76,6 +76,9 @@ namespace Microsoft\BingAds\V12\Reporting;
 
         /** The ad group status. */
         const AdGroupStatus = 'AdGroupStatus';
+
+        /** The average position of the ad on a webpage. */
+        const AveragePosition = 'AveragePosition';
     }
 
 }

--- a/src/V12/Reporting/ReportRequestStatus.php
+++ b/src/V12/Reporting/ReportRequestStatus.php
@@ -13,7 +13,7 @@ namespace Microsoft\BingAds\V12\Reporting;
     final class ReportRequestStatus
     {
         /**
-         * The URL from where the report can be downloaded.
+         * The encoded URL from where the report can be downloaded.
          * @var string
          */
         public $ReportDownloadUrl;

--- a/src/V13/CampaignManagement/Company.php
+++ b/src/V13/CampaignManagement/Company.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Microsoft\BingAds\V13\CampaignManagement;
+
+{
+    /**
+     * Defines the profile data for a company.
+     * @link https://docs.microsoft.com/en-us/advertising/campaign-management-service/company?view=bingads-13 Company Data Object
+     * 
+     * @used-by SearchCompaniesResponse
+     */
+    final class Company
+    {
+        /**
+         * The full https path for the company's logo image.
+         * @var string
+         */
+        public $LogoUrl;
+
+        /**
+         * The company name.
+         * @var string
+         */
+        public $Name;
+
+        /**
+         * The company name profile identifier that you can use with ProfileCriterion.
+         * @var integer
+         */
+        public $ProfileId;
+
+        /**
+         * The company name profile status.
+         * @var string
+         */
+        public $Status;
+    }
+
+}

--- a/src/V13/CampaignManagement/ConversionGoal.php
+++ b/src/V13/CampaignManagement/ConversionGoal.php
@@ -33,7 +33,7 @@ namespace Microsoft\BingAds\V13\CampaignManagement;
         public $CountType;
 
         /**
-         * Reserved for future use.
+         * Determines whether or not to exclude data otherwise related to this conversion goal from a subset of performance report columns.
          * @var boolean
          */
         public $ExcludeFromBidding;

--- a/src/V13/CampaignManagement/DynamicSearchAdsSetting.php
+++ b/src/V13/CampaignManagement/DynamicSearchAdsSetting.php
@@ -24,7 +24,7 @@ namespace Microsoft\BingAds\V13\CampaignManagement;
         public $Language;
 
         /**
-         * Reserved for future use.
+         * The page feed identifiers for dynamic search ads.
          * @var integer[]
          */
         public $PageFeedIds;

--- a/src/V13/CampaignManagement/GetProfileDataFileUrlRequest.php
+++ b/src/V13/CampaignManagement/GetProfileDataFileUrlRequest.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V13\CampaignManagement;
 
 {
     /**
-     * Gets a temporary URL that you can use to download company name, industry, or job function profile data.
+     * Gets a temporary URL that you can use to download industry or job function profile data.
      * @link https://docs.microsoft.com/en-us/advertising/campaign-management-service/getprofiledatafileurl?view=bingads-13 GetProfileDataFileUrl Request Object
      * 
      * @uses ProfileType
@@ -19,7 +19,7 @@ namespace Microsoft\BingAds\V13\CampaignManagement;
         public $LanguageLocale;
 
         /**
-         * Determines whether you want company name, industry, or job function profile data.
+         * Determines whether you want industry or job function profile data.
          * @var ProfileType
          */
         public $ProfileType;

--- a/src/V13/CampaignManagement/GetProfileDataFileUrlResponse.php
+++ b/src/V13/CampaignManagement/GetProfileDataFileUrlResponse.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V13\CampaignManagement;
 
 {
     /**
-     * Gets a temporary URL that you can use to download company name, industry, or job function profile data.
+     * Gets a temporary URL that you can use to download industry or job function profile data.
      * @link https://docs.microsoft.com/en-us/advertising/campaign-management-service/getprofiledatafileurl?view=bingads-13 GetProfileDataFileUrl Response Object
      * 
      * @used-by BingAdsCampaignManagementService::GetProfileDataFileUrl

--- a/src/V13/CampaignManagement/ProfileCriterion.php
+++ b/src/V13/CampaignManagement/ProfileCriterion.php
@@ -12,7 +12,7 @@ namespace Microsoft\BingAds\V13\CampaignManagement;
     final class ProfileCriterion extends Criterion
     {
         /**
-         * The identifier of the audience profile that you want to target.
+         * The identifier of the company name, industry, or job function profile that you want to target.
          * @var integer
          */
         public $ProfileId;

--- a/src/V13/CampaignManagement/SearchCompaniesRequest.php
+++ b/src/V13/CampaignManagement/SearchCompaniesRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Microsoft\BingAds\V13\CampaignManagement;
+
+{
+    /**
+     * Search for profile data by company name.
+     * @link https://docs.microsoft.com/en-us/advertising/campaign-management-service/searchcompanies?view=bingads-13 SearchCompanies Request Object
+     * 
+     * @used-by BingAdsCampaignManagementService::SearchCompanies
+     */
+    final class SearchCompaniesRequest
+    {
+        /**
+         * The company name filter string.
+         * @var string
+         */
+        public $CompanyNameFilter;
+
+        /**
+         * The language and locale of the profile display names.
+         * @var string
+         */
+        public $LanguageLocale;
+    }
+}

--- a/src/V13/CampaignManagement/SearchCompaniesResponse.php
+++ b/src/V13/CampaignManagement/SearchCompaniesResponse.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Microsoft\BingAds\V13\CampaignManagement;
+
+{
+    /**
+     * Search for profile data by company name.
+     * @link https://docs.microsoft.com/en-us/advertising/campaign-management-service/searchcompanies?view=bingads-13 SearchCompanies Response Object
+     * 
+     * @uses Company
+     * @used-by BingAdsCampaignManagementService::SearchCompanies
+     */
+    final class SearchCompaniesResponse
+    {
+        /**
+         * The list of companies that match the requested company name filter.
+         * @var Company[]
+         */
+        public $Companies;
+    }
+}

--- a/src/V13/CustomerManagement/AccountInfo.php
+++ b/src/V13/CustomerManagement/AccountInfo.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
 
 {
     /**
-     * Defines an account identification object that contains information that identifies an account.
+     * Defines an object that contains an account's identifier, name, and number.
      * @link https://docs.microsoft.com/en-us/advertising/customer-management-service/accountinfo?view=bingads-13 AccountInfo Data Object
      * 
      * @uses AccountLifeCycleStatus

--- a/src/V13/CustomerManagement/ClientLink.php
+++ b/src/V13/CustomerManagement/ClientLink.php
@@ -16,43 +16,43 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
     final class ClientLink
     {
         /**
-         * Reserved for future use.
+         * Determines whether the link is to a client ad account or a client customer.
          * @var string
          */
         public $Type;
 
         /**
-         * The identifier of the client account or customer to manage.
+         * The identifier of the client ad account or client customer to manage.
          * @var integer
          */
         public $ClientEntityId;
 
         /**
-         * The number of the client account or customer to manage.
+         * The number of the client ad account or client customer to manage.
          * @var string
          */
         public $ClientEntityNumber;
 
         /**
-         * The name of the client account or customer to manage.
+         * The name of the client ad account or client customer to manage.
          * @var string
          */
         public $ClientEntityName;
 
         /**
-         * The identifier of the customer who manages or is requesting to manage the client account.
+         * The identifier of the customer who manages or is requesting to manage the client ad account.
          * @var integer
          */
         public $ManagingCustomerId;
 
         /**
-         * The number of the customer who manages or is requesting to manage the client account.
+         * The number of the customer who manages or is requesting to manage the client ad account.
          * @var string
          */
         public $ManagingCustomerNumber;
 
         /**
-         * The name of the customer who manages or is requesting to manage the client account.
+         * The name of the customer who manages or is requesting to manage the client ad account.
          * @var string
          */
         public $ManagingCustomerName;
@@ -76,7 +76,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
         public $InviterEmail;
 
         /**
-         * The name of the parent customer of the user who  created the client link request.
+         * The name of the parent customer of the user who created the client link request.
          * @var string
          */
         public $InviterName;
@@ -88,7 +88,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
         public $InviterPhone;
 
         /**
-         * Determines whether the owner of the client account or the managing customer is responsible for billing payments.
+         * Determines whether the owner of the client ad account or the managing customer is responsible for billing payments.
          * @var boolean
          */
         public $IsBillToClient;
@@ -106,7 +106,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
         public $Status;
 
         /**
-         * Determines whether or not to send email notification of the client link invitation to the primary user of the client account.
+         * Determines whether or not to send email notification of the client link invitation to the primary user of the client ad account.
          * @var boolean
          */
         public $SuppressNotification;
@@ -136,7 +136,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
         public $ForwardCompatibilityMap;
 
         /**
-         * Reserved for future use.
+         * Determines whether the user's access to the accounts is restricted by customer hierarchy i.e., customer level client linking.
          * @var string
          */
         public $CustomerLinkPermission;

--- a/src/V13/CustomerManagement/CustomerInfo.php
+++ b/src/V13/CustomerManagement/CustomerInfo.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
 
 {
     /**
-     * Defines a customer identification object that contains information that identifies a customer.
+     * Defines an object that contains a customer's identifier and name.
      * @link https://docs.microsoft.com/en-us/advertising/customer-management-service/customerinfo?view=bingads-13 CustomerInfo Data Object
      * 
      * @used-by AdvertiserAccount

--- a/src/V13/CustomerManagement/CustomerRole.php
+++ b/src/V13/CustomerManagement/CustomerRole.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
 
 {
     /**
-     * Defines the role a user has for one customer or list of accounts within a customer.
+     * Defines account access rights for a person who acts on behalf of a specific customer.
      * @link https://docs.microsoft.com/en-us/advertising/customer-management-service/customerrole?view=bingads-13 CustomerRole Data Object
      * 
      * @used-by GetUserResponse
@@ -36,7 +36,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
         public $LinkedAccountIds;
 
         /**
-         * Reserved for future use.
+         * Determines whether the user's access to the accounts is restricted by customer hierarchy i.e., customer level client linking.
          * @var string
          */
         public $CustomerLinkPermission;

--- a/src/V13/CustomerManagement/GetAccountPilotFeaturesRequest.php
+++ b/src/V13/CustomerManagement/GetAccountPilotFeaturesRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Microsoft\BingAds\V13\CustomerManagement;
+
+{
+    /**
+     * Gets a list of the pilot programs that are enabled for the specified account.
+     * @link https://docs.microsoft.com/en-us/advertising/customer-management-service/getaccountpilotfeatures?view=bingads-13 GetAccountPilotFeatures Request Object
+     * 
+     * @used-by BingAdsCustomerManagementService::GetAccountPilotFeatures
+     */
+    final class GetAccountPilotFeaturesRequest
+    {
+        /**
+         * The identifier of the account used to get a list of pilot features.
+         * @var integer
+         */
+        public $AccountId;
+    }
+}

--- a/src/V13/CustomerManagement/GetAccountPilotFeaturesResponse.php
+++ b/src/V13/CustomerManagement/GetAccountPilotFeaturesResponse.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Microsoft\BingAds\V13\CustomerManagement;
+
+{
+    /**
+     * Gets a list of the pilot programs that are enabled for the specified account.
+     * @link https://docs.microsoft.com/en-us/advertising/customer-management-service/getaccountpilotfeatures?view=bingads-13 GetAccountPilotFeatures Response Object
+     * 
+     * @used-by BingAdsCustomerManagementService::GetAccountPilotFeatures
+     */
+    final class GetAccountPilotFeaturesResponse
+    {
+        /**
+         * A list of integers that identifies the pilot features that are enabled for all of the customer's accounts.
+         * @var integer[]
+         */
+        public $FeaturePilotFlags;
+    }
+}

--- a/src/V13/CustomerManagement/GetAccountsInfoRequest.php
+++ b/src/V13/CustomerManagement/GetAccountsInfoRequest.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
 
 {
     /**
-     * Gets a list of objects that contains account identification information, for example the name and identifier of the account, for the specified customer.
+     * Gets the identifiers, names, and numbers of accounts that are accessible from the specified customer.
      * @link https://docs.microsoft.com/en-us/advertising/customer-management-service/getaccountsinfo?view=bingads-13 GetAccountsInfo Request Object
      * 
      * @used-by BingAdsCustomerManagementService::GetAccountsInfo
@@ -12,13 +12,13 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
     final class GetAccountsInfoRequest
     {
         /**
-         * The identifier of the customer who owns the accounts to get.
+         * The identifier of the customer used to get the account information.
          * @var integer
          */
         public $CustomerId;
 
         /**
-         * Determines whether to return only the accounts that belong to the customer or to also return the accounts that the customer manages for other customers.
+         * Determines whether to return only the ad accounts that belong to the customer or to also return linked ad accounts under other customers.
          * @var boolean
          */
         public $OnlyParentAccounts;

--- a/src/V13/CustomerManagement/GetAccountsInfoResponse.php
+++ b/src/V13/CustomerManagement/GetAccountsInfoResponse.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
 
 {
     /**
-     * Gets a list of objects that contains account identification information, for example the name and identifier of the account, for the specified customer.
+     * Gets the identifiers, names, and numbers of accounts that are accessible from the specified customer.
      * @link https://docs.microsoft.com/en-us/advertising/customer-management-service/getaccountsinfo?view=bingads-13 GetAccountsInfo Response Object
      * 
      * @uses AccountInfo
@@ -13,7 +13,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
     final class GetAccountsInfoResponse
     {
         /**
-         * An array of AccountInfo objects that identifies the list of accounts that the customer owns.
+         * The list of information about ad accounts that match the request criteria.
          * @var AccountInfo[]
          */
         public $AccountsInfo;

--- a/src/V13/CustomerManagement/GetCustomerPilotFeaturesRequest.php
+++ b/src/V13/CustomerManagement/GetCustomerPilotFeaturesRequest.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
 
 {
     /**
-     * Gets a list of the pilot programs in which the specified customer participates.
+     * Gets a list of the pilot programs that are enabled for all of the customer's accounts.
      * @link https://docs.microsoft.com/en-us/advertising/customer-management-service/getcustomerpilotfeatures?view=bingads-13 GetCustomerPilotFeatures Request Object
      * 
      * @used-by BingAdsCustomerManagementService::GetCustomerPilotFeatures
@@ -12,7 +12,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
     final class GetCustomerPilotFeaturesRequest
     {
         /**
-         * The identifier of the customer whose list of pilot programs you want to get.
+         * The identifier of the customer used to get a list of pilot features.
          * @var integer
          */
         public $CustomerId;

--- a/src/V13/CustomerManagement/GetCustomerPilotFeaturesResponse.php
+++ b/src/V13/CustomerManagement/GetCustomerPilotFeaturesResponse.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
 
 {
     /**
-     * Gets a list of the pilot programs in which the specified customer participates.
+     * Gets a list of the pilot programs that are enabled for all of the customer's accounts.
      * @link https://docs.microsoft.com/en-us/advertising/customer-management-service/getcustomerpilotfeatures?view=bingads-13 GetCustomerPilotFeatures Response Object
      * 
      * @used-by BingAdsCustomerManagementService::GetCustomerPilotFeatures
@@ -12,7 +12,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
     final class GetCustomerPilotFeaturesResponse
     {
         /**
-         * A list of integers that identifies the pilot programs in which the customer participates.
+         * A list of integers that identifies the pilot features that are enabled for all of the customer's accounts.
          * @var integer[]
          */
         public $FeaturePilotFlags;

--- a/src/V13/CustomerManagement/GetCustomersInfoRequest.php
+++ b/src/V13/CustomerManagement/GetCustomersInfoRequest.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
 
 {
     /**
-     * Gets a list of objects that contain customer identification information, for example the name and identifier of the customer.
+     * Gets the identifiers and names of customers that are accessible to the current authenticated user.
      * @link https://docs.microsoft.com/en-us/advertising/customer-management-service/getcustomersinfo?view=bingads-13 GetCustomersInfo Request Object
      * 
      * @used-by BingAdsCustomerManagementService::GetCustomersInfo

--- a/src/V13/CustomerManagement/GetCustomersInfoResponse.php
+++ b/src/V13/CustomerManagement/GetCustomersInfoResponse.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
 
 {
     /**
-     * Gets a list of objects that contain customer identification information, for example the name and identifier of the customer.
+     * Gets the identifiers and names of customers that are accessible to the current authenticated user.
      * @link https://docs.microsoft.com/en-us/advertising/customer-management-service/getcustomersinfo?view=bingads-13 GetCustomersInfo Response Object
      * 
      * @uses CustomerInfo
@@ -13,7 +13,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
     final class GetCustomersInfoResponse
     {
         /**
-         * An array of CustomerInfo objects that identifies the list of customers that meet the filter criteria.
+         * The list of information about customers that match the request criteria.
          * @var CustomerInfo[]
          */
         public $CustomersInfo;

--- a/src/V13/CustomerManagement/GetLinkedAccountsAndCustomersInfoRequest.php
+++ b/src/V13/CustomerManagement/GetLinkedAccountsAndCustomersInfoRequest.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
 
 {
     /**
-     * Reserved for future use.
+     * Gets the customer and account hierarchy under a specified customer.
      * @link https://docs.microsoft.com/en-us/advertising/customer-management-service/getlinkedaccountsandcustomersinfo?view=bingads-13 GetLinkedAccountsAndCustomersInfo Request Object
      * 
      * @used-by BingAdsCustomerManagementService::GetLinkedAccountsAndCustomersInfo
@@ -12,13 +12,13 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
     final class GetLinkedAccountsAndCustomersInfoRequest
     {
         /**
-         * Reserved for future use.
+         * The identifier of the customer whose hierarchy you want to get.
          * @var integer
          */
         public $CustomerId;
 
         /**
-         * Reserved for future use.
+         * Determines whether to return only the ad accounts that belong to the customer or to also return linked customers and linked ad accounts under other customers.
          * @var boolean
          */
         public $OnlyParentAccounts;

--- a/src/V13/CustomerManagement/GetLinkedAccountsAndCustomersInfoResponse.php
+++ b/src/V13/CustomerManagement/GetLinkedAccountsAndCustomersInfoResponse.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
 
 {
     /**
-     * Reserved for future use.
+     * Gets the customer and account hierarchy under a specified customer.
      * @link https://docs.microsoft.com/en-us/advertising/customer-management-service/getlinkedaccountsandcustomersinfo?view=bingads-13 GetLinkedAccountsAndCustomersInfo Response Object
      * 
      * @uses AccountInfo
@@ -14,13 +14,13 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
     final class GetLinkedAccountsAndCustomersInfoResponse
     {
         /**
-         * Reserved for future use.
+         * The list of information about ad accounts that match the request criteria.
          * @var AccountInfo[]
          */
         public $AccountsInfo;
 
         /**
-         * Reserved for future use.
+         * The list of information about customers that match the request criteria.
          * @var CustomerInfo[]
          */
         public $CustomersInfo;

--- a/src/V13/CustomerManagement/SearchAccountsRequest.php
+++ b/src/V13/CustomerManagement/SearchAccountsRequest.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
 
 {
     /**
-     * Searches for accounts that match a specified criteria.
+     * Searches for accounts that match the request criteria.
      * @link https://docs.microsoft.com/en-us/advertising/customer-management-service/searchaccounts?view=bingads-13 SearchAccounts Request Object
      * 
      * @uses Predicate

--- a/src/V13/CustomerManagement/SearchAccountsResponse.php
+++ b/src/V13/CustomerManagement/SearchAccountsResponse.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
 
 {
     /**
-     * Searches for accounts that match a specified criteria.
+     * Searches for accounts that match the request criteria.
      * @link https://docs.microsoft.com/en-us/advertising/customer-management-service/searchaccounts?view=bingads-13 SearchAccounts Response Object
      * 
      * @uses AdvertiserAccount
@@ -13,7 +13,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
     final class SearchAccountsResponse
     {
         /**
-         * A list of accounts that meet the specified criteria.
+         * A list of accounts that meet the request criteria.
          * @var AdvertiserAccount[]
          */
         public $Accounts;

--- a/src/V13/CustomerManagement/SearchCustomersRequest.php
+++ b/src/V13/CustomerManagement/SearchCustomersRequest.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
 
 {
     /**
-     * Searches for customers that match a specified criteria.
+     * Searches for customers that match the request criteria.
      * @link https://docs.microsoft.com/en-us/advertising/customer-management-service/searchcustomers?view=bingads-13 SearchCustomers Request Object
      * 
      * @uses Predicate

--- a/src/V13/CustomerManagement/SearchCustomersResponse.php
+++ b/src/V13/CustomerManagement/SearchCustomersResponse.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
 
 {
     /**
-     * Searches for customers that match a specified criteria.
+     * Searches for customers that match the request criteria.
      * @link https://docs.microsoft.com/en-us/advertising/customer-management-service/searchcustomers?view=bingads-13 SearchCustomers Response Object
      * 
      * @uses Customer
@@ -13,7 +13,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
     final class SearchCustomersResponse
     {
         /**
-         * A  list of customers that meet the specified criteria.
+         * A  list of customers that meet the request criteria.
          * @var Customer[]
          */
         public $Customers;

--- a/src/V13/CustomerManagement/SearchUserInvitationsRequest.php
+++ b/src/V13/CustomerManagement/SearchUserInvitationsRequest.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
 
 {
     /**
-     * Searches for user invitations that match a specified criteria.
+     * Searches for user invitations that match the request criteria.
      * @link https://docs.microsoft.com/en-us/advertising/customer-management-service/searchuserinvitations?view=bingads-13 SearchUserInvitations Request Object
      * 
      * @uses Predicate

--- a/src/V13/CustomerManagement/SearchUserInvitationsResponse.php
+++ b/src/V13/CustomerManagement/SearchUserInvitationsResponse.php
@@ -4,7 +4,7 @@ namespace Microsoft\BingAds\V13\CustomerManagement;
 
 {
     /**
-     * Searches for user invitations that match a specified criteria.
+     * Searches for user invitations that match the request criteria.
      * @link https://docs.microsoft.com/en-us/advertising/customer-management-service/searchuserinvitations?view=bingads-13 SearchUserInvitations Response Object
      * 
      * @uses UserInvitation

--- a/src/V13/Reporting/AccountPerformanceReportColumn.php
+++ b/src/V13/Reporting/AccountPerformanceReportColumn.php
@@ -172,6 +172,24 @@ namespace Microsoft\BingAds\V13\Reporting;
 
         /** The percentage of times your ad showed in the mainline, the top placement where ads appear above the search results, out of your total impressions. */
         const TopImpressionRatePercent = 'TopImpressionRatePercent';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The revenue optionally reported by the advertiser as a result of conversions. */
+        const AllRevenue = 'AllRevenue';
+
+        /** The conversion rate as a percentage. */
+        const AllConversionRate = 'AllConversionRate';
+
+        /** The cost per conversion. */
+        const AllCostPerConversion = 'AllCostPerConversion';
+
+        /** The return on ad spend (ROAS). */
+        const AllReturnOnAdSpend = 'AllReturnOnAdSpend';
+
+        /** The revenue per conversion. */
+        const AllRevenuePerConversion = 'AllRevenuePerConversion';
     }
 
 }

--- a/src/V13/Reporting/AdDynamicTextPerformanceReportColumn.php
+++ b/src/V13/Reporting/AdDynamicTextPerformanceReportColumn.php
@@ -136,6 +136,15 @@ namespace Microsoft\BingAds\V13\Reporting;
 
         /** The labels applied to the ad. */
         const AdLabels = 'AdLabels';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The conversion rate as a percentage. */
+        const AllConversionRate = 'AllConversionRate';
+
+        /** The cost per conversion. */
+        const AllCostPerConversion = 'AllCostPerConversion';
     }
 
 }

--- a/src/V13/Reporting/AdExtensionByAdReportColumn.php
+++ b/src/V13/Reporting/AdExtensionByAdReportColumn.php
@@ -136,6 +136,24 @@ namespace Microsoft\BingAds\V13\Reporting;
 
         /** The title part 3 attribute of an ad. */
         const TitlePart3 = 'TitlePart3';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The revenue optionally reported by the advertiser as a result of conversions. */
+        const AllRevenue = 'AllRevenue';
+
+        /** The conversion rate as a percentage. */
+        const AllConversionRate = 'AllConversionRate';
+
+        /** The cost per conversion. */
+        const AllCostPerConversion = 'AllCostPerConversion';
+
+        /** The return on ad spend (ROAS). */
+        const AllReturnOnAdSpend = 'AllReturnOnAdSpend';
+
+        /** The revenue per conversion. */
+        const AllRevenuePerConversion = 'AllRevenuePerConversion';
     }
 
 }

--- a/src/V13/Reporting/AdExtensionByKeywordReportColumn.php
+++ b/src/V13/Reporting/AdExtensionByKeywordReportColumn.php
@@ -127,6 +127,24 @@ namespace Microsoft\BingAds\V13\Reporting;
 
         /** The keyword status. */
         const KeywordStatus = 'KeywordStatus';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The revenue optionally reported by the advertiser as a result of conversions. */
+        const AllRevenue = 'AllRevenue';
+
+        /** The conversion rate as a percentage. */
+        const AllConversionRate = 'AllConversionRate';
+
+        /** The cost per conversion. */
+        const AllCostPerConversion = 'AllCostPerConversion';
+
+        /** The return on ad spend (ROAS). */
+        const AllReturnOnAdSpend = 'AllReturnOnAdSpend';
+
+        /** The revenue per conversion. */
+        const AllRevenuePerConversion = 'AllRevenuePerConversion';
     }
 
 }

--- a/src/V13/Reporting/AdExtensionDetailReportColumn.php
+++ b/src/V13/Reporting/AdExtensionDetailReportColumn.php
@@ -124,6 +124,24 @@ namespace Microsoft\BingAds\V13\Reporting;
 
         /** The ad status. */
         const AdStatus = 'AdStatus';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The revenue optionally reported by the advertiser as a result of conversions. */
+        const AllRevenue = 'AllRevenue';
+
+        /** The conversion rate as a percentage. */
+        const AllConversionRate = 'AllConversionRate';
+
+        /** The cost per conversion. */
+        const AllCostPerConversion = 'AllCostPerConversion';
+
+        /** The return on ad spend (ROAS). */
+        const AllReturnOnAdSpend = 'AllReturnOnAdSpend';
+
+        /** The revenue per conversion. */
+        const AllRevenuePerConversion = 'AllRevenuePerConversion';
     }
 
 }

--- a/src/V13/Reporting/AdGroupPerformanceReportColumn.php
+++ b/src/V13/Reporting/AdGroupPerformanceReportColumn.php
@@ -208,6 +208,27 @@ namespace Microsoft\BingAds\V13\Reporting;
 
         /** The percentage of times your ad showed in the mainline, the top placement where ads appear above the search results, out of your total impressions. */
         const TopImpressionRatePercent = 'TopImpressionRatePercent';
+
+        /** The Microsoft Advertising assigned identifier of an experiment campaign. */
+        const BaseCampaignId = 'BaseCampaignId';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The revenue optionally reported by the advertiser as a result of conversions. */
+        const AllRevenue = 'AllRevenue';
+
+        /** The conversion rate as a percentage. */
+        const AllConversionRate = 'AllConversionRate';
+
+        /** The cost per conversion. */
+        const AllCostPerConversion = 'AllCostPerConversion';
+
+        /** The return on ad spend (ROAS). */
+        const AllReturnOnAdSpend = 'AllReturnOnAdSpend';
+
+        /** The revenue per conversion. */
+        const AllRevenuePerConversion = 'AllRevenuePerConversion';
     }
 
 }

--- a/src/V13/Reporting/AdPerformanceReportColumn.php
+++ b/src/V13/Reporting/AdPerformanceReportColumn.php
@@ -190,6 +190,27 @@ namespace Microsoft\BingAds\V13\Reporting;
 
         /** The campaign type. */
         const CampaignType = 'CampaignType';
+
+        /** The Microsoft Advertising assigned identifier of an experiment campaign. */
+        const BaseCampaignId = 'BaseCampaignId';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The revenue optionally reported by the advertiser as a result of conversions. */
+        const AllRevenue = 'AllRevenue';
+
+        /** The conversion rate as a percentage. */
+        const AllConversionRate = 'AllConversionRate';
+
+        /** The cost per conversion. */
+        const AllCostPerConversion = 'AllCostPerConversion';
+
+        /** The return on ad spend (ROAS). */
+        const AllReturnOnAdSpend = 'AllReturnOnAdSpend';
+
+        /** The revenue per conversion. */
+        const AllRevenuePerConversion = 'AllRevenuePerConversion';
     }
 
 }

--- a/src/V13/Reporting/AgeGenderAudienceReportColumn.php
+++ b/src/V13/Reporting/AgeGenderAudienceReportColumn.php
@@ -50,7 +50,7 @@ namespace Microsoft\BingAds\V13\Reporting;
         /** Clicks are what you pay for. */
         const Clicks = 'Clicks';
 
-        /** A conversion is a click that results in a sale or another measure of success. */
+        /** The number of conversions. */
         const Conversions = 'Conversions';
 
         /** The sum of your cost-per-click (CPC) charges for your ads and keywords. */
@@ -76,6 +76,15 @@ namespace Microsoft\BingAds\V13\Reporting;
 
         /** The ad group status. */
         const AdGroupStatus = 'AdGroupStatus';
+
+        /** The Microsoft Advertising assigned identifier of an experiment campaign. */
+        const BaseCampaignId = 'BaseCampaignId';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The revenue optionally reported by the advertiser as a result of conversions. */
+        const AllRevenue = 'AllRevenue';
     }
 
 }

--- a/src/V13/Reporting/AudiencePerformanceReportColumn.php
+++ b/src/V13/Reporting/AudiencePerformanceReportColumn.php
@@ -41,7 +41,7 @@ namespace Microsoft\BingAds\V13\Reporting;
         /** The audience name. */
         const AudienceName = 'AudienceName';
 
-        /** The status of the association between the ad group and remarketing list, which indicates whether ads are eligible to display. */
+        /** The status of the association between the audience and either an ad group or campaign. */
         const AssociationStatus = 'AssociationStatus';
 
         /** This attribute reflects the current value of your ad group's audience bid adjustment, even if a different bid adjustment value was used when the ad was shown. */
@@ -97,6 +97,30 @@ namespace Microsoft\BingAds\V13\Reporting;
 
         /** The audience type. */
         const AudienceType = 'AudienceType';
+
+        /** The Microsoft Advertising assigned identifier of an experiment campaign. */
+        const BaseCampaignId = 'BaseCampaignId';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The revenue optionally reported by the advertiser as a result of conversions. */
+        const AllRevenue = 'AllRevenue';
+
+        /** The conversion rate as a percentage. */
+        const AllConversionRate = 'AllConversionRate';
+
+        /** The cost per conversion. */
+        const AllCostPerConversion = 'AllCostPerConversion';
+
+        /** The return on ad spend (ROAS). */
+        const AllReturnOnAdSpend = 'AllReturnOnAdSpend';
+
+        /** The revenue per conversion. */
+        const AllRevenuePerConversion = 'AllRevenuePerConversion';
+
+        /** The Microsoft Advertising assigned identifier of the association between the audience and either an ad group or campaign. */
+        const AssociationId = 'AssociationId';
     }
 
 }

--- a/src/V13/Reporting/CampaignPerformanceReportColumn.php
+++ b/src/V13/Reporting/CampaignPerformanceReportColumn.php
@@ -229,6 +229,27 @@ namespace Microsoft\BingAds\V13\Reporting;
 
         /** The percentage of times your ad showed in the mainline, the top placement where ads appear above the search results, out of your total impressions. */
         const TopImpressionRatePercent = 'TopImpressionRatePercent';
+
+        /** The Microsoft Advertising assigned identifier of an experiment campaign. */
+        const BaseCampaignId = 'BaseCampaignId';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The revenue optionally reported by the advertiser as a result of conversions. */
+        const AllRevenue = 'AllRevenue';
+
+        /** The conversion rate as a percentage. */
+        const AllConversionRate = 'AllConversionRate';
+
+        /** The cost per conversion. */
+        const AllCostPerConversion = 'AllCostPerConversion';
+
+        /** The return on ad spend (ROAS). */
+        const AllReturnOnAdSpend = 'AllReturnOnAdSpend';
+
+        /** The revenue per conversion. */
+        const AllRevenuePerConversion = 'AllRevenuePerConversion';
     }
 
 }

--- a/src/V13/Reporting/ConversionPerformanceReportColumn.php
+++ b/src/V13/Reporting/ConversionPerformanceReportColumn.php
@@ -94,6 +94,24 @@ namespace Microsoft\BingAds\V13\Reporting;
 
         /** The keyword status. */
         const KeywordStatus = 'KeywordStatus';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The revenue optionally reported by the advertiser as a result of conversions. */
+        const AllRevenue = 'AllRevenue';
+
+        /** The conversion rate as a percentage. */
+        const AllConversionRate = 'AllConversionRate';
+
+        /** The cost per conversion. */
+        const AllCostPerConversion = 'AllCostPerConversion';
+
+        /** The return on ad spend (ROAS). */
+        const AllReturnOnAdSpend = 'AllReturnOnAdSpend';
+
+        /** The revenue per conversion. */
+        const AllRevenuePerConversion = 'AllRevenuePerConversion';
     }
 
 }

--- a/src/V13/Reporting/DSAAutoTargetPerformanceReportColumn.php
+++ b/src/V13/Reporting/DSAAutoTargetPerformanceReportColumn.php
@@ -127,6 +127,24 @@ namespace Microsoft\BingAds\V13\Reporting;
 
         /** The revenue per assist. */
         const RevenuePerAssist = 'RevenuePerAssist';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The revenue optionally reported by the advertiser as a result of conversions. */
+        const AllRevenue = 'AllRevenue';
+
+        /** The conversion rate as a percentage. */
+        const AllConversionRate = 'AllConversionRate';
+
+        /** The cost per conversion. */
+        const AllCostPerConversion = 'AllCostPerConversion';
+
+        /** The return on ad spend (ROAS). */
+        const AllReturnOnAdSpend = 'AllReturnOnAdSpend';
+
+        /** The revenue per conversion. */
+        const AllRevenuePerConversion = 'AllRevenuePerConversion';
     }
 
 }

--- a/src/V13/Reporting/DSACategoryPerformanceReportColumn.php
+++ b/src/V13/Reporting/DSACategoryPerformanceReportColumn.php
@@ -121,6 +121,24 @@ namespace Microsoft\BingAds\V13\Reporting;
 
         /** The revenue per assist. */
         const RevenuePerAssist = 'RevenuePerAssist';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The revenue optionally reported by the advertiser as a result of conversions. */
+        const AllRevenue = 'AllRevenue';
+
+        /** The conversion rate as a percentage. */
+        const AllConversionRate = 'AllConversionRate';
+
+        /** The cost per conversion. */
+        const AllCostPerConversion = 'AllCostPerConversion';
+
+        /** The return on ad spend (ROAS). */
+        const AllReturnOnAdSpend = 'AllReturnOnAdSpend';
+
+        /** The revenue per conversion. */
+        const AllRevenuePerConversion = 'AllRevenuePerConversion';
     }
 
 }

--- a/src/V13/Reporting/DSASearchQueryPerformanceReportColumn.php
+++ b/src/V13/Reporting/DSASearchQueryPerformanceReportColumn.php
@@ -142,6 +142,24 @@ namespace Microsoft\BingAds\V13\Reporting;
 
         /** The feed URL will appear either as "True" or "False". */
         const FeedUrl = 'FeedUrl';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The revenue optionally reported by the advertiser as a result of conversions. */
+        const AllRevenue = 'AllRevenue';
+
+        /** The conversion rate as a percentage. */
+        const AllConversionRate = 'AllConversionRate';
+
+        /** The cost per conversion. */
+        const AllCostPerConversion = 'AllCostPerConversion';
+
+        /** The return on ad spend (ROAS). */
+        const AllReturnOnAdSpend = 'AllReturnOnAdSpend';
+
+        /** The revenue per conversion. */
+        const AllRevenuePerConversion = 'AllRevenuePerConversion';
     }
 
 }

--- a/src/V13/Reporting/DestinationUrlPerformanceReportColumn.php
+++ b/src/V13/Reporting/DestinationUrlPerformanceReportColumn.php
@@ -148,6 +148,24 @@ namespace Microsoft\BingAds\V13\Reporting;
 
         /** The final URL suffix can include tracking parameters that will be appended to the end of your landing page URL. */
         const FinalUrlSuffix = 'FinalUrlSuffix';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The revenue optionally reported by the advertiser as a result of conversions. */
+        const AllRevenue = 'AllRevenue';
+
+        /** The conversion rate as a percentage. */
+        const AllConversionRate = 'AllConversionRate';
+
+        /** The cost per conversion. */
+        const AllCostPerConversion = 'AllCostPerConversion';
+
+        /** The return on ad spend (ROAS). */
+        const AllReturnOnAdSpend = 'AllReturnOnAdSpend';
+
+        /** The revenue per conversion. */
+        const AllRevenuePerConversion = 'AllRevenuePerConversion';
     }
 
 }

--- a/src/V13/Reporting/GeographicPerformanceReportColumn.php
+++ b/src/V13/Reporting/GeographicPerformanceReportColumn.php
@@ -148,6 +148,27 @@ namespace Microsoft\BingAds\V13\Reporting;
 
         /** The Microsoft Advertising identifier of the location where the user was physically located when they clicked the ad. */
         const LocationId = 'LocationId';
+
+        /** The Microsoft Advertising assigned identifier of an experiment campaign. */
+        const BaseCampaignId = 'BaseCampaignId';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The revenue optionally reported by the advertiser as a result of conversions. */
+        const AllRevenue = 'AllRevenue';
+
+        /** The conversion rate as a percentage. */
+        const AllConversionRate = 'AllConversionRate';
+
+        /** The cost per conversion. */
+        const AllCostPerConversion = 'AllCostPerConversion';
+
+        /** The return on ad spend (ROAS). */
+        const AllReturnOnAdSpend = 'AllReturnOnAdSpend';
+
+        /** The revenue per conversion. */
+        const AllRevenuePerConversion = 'AllRevenuePerConversion';
     }
 
 }

--- a/src/V13/Reporting/KeywordPerformanceReportColumn.php
+++ b/src/V13/Reporting/KeywordPerformanceReportColumn.php
@@ -197,6 +197,27 @@ namespace Microsoft\BingAds\V13\Reporting;
 
         /** The final URL suffix can include tracking parameters that will be appended to the end of your landing page URL. */
         const FinalUrlSuffix = 'FinalUrlSuffix';
+
+        /** The Microsoft Advertising assigned identifier of an experiment campaign. */
+        const BaseCampaignId = 'BaseCampaignId';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The revenue optionally reported by the advertiser as a result of conversions. */
+        const AllRevenue = 'AllRevenue';
+
+        /** The conversion rate as a percentage. */
+        const AllConversionRate = 'AllConversionRate';
+
+        /** The cost per conversion. */
+        const AllCostPerConversion = 'AllCostPerConversion';
+
+        /** The return on ad spend (ROAS). */
+        const AllReturnOnAdSpend = 'AllReturnOnAdSpend';
+
+        /** The revenue per conversion. */
+        const AllRevenuePerConversion = 'AllRevenuePerConversion';
     }
 
 }

--- a/src/V13/Reporting/ProductDimensionPerformanceReportColumn.php
+++ b/src/V13/Reporting/ProductDimensionPerformanceReportColumn.php
@@ -209,8 +209,29 @@ namespace Microsoft\BingAds\V13\Reporting;
         /** The number of times your ad is shown in the top position as a percentage of the total available impressions in the market you were targeting. */
         const AbsoluteTopImpressionSharePercent = 'AbsoluteTopImpressionSharePercent';
 
-        /** Conversions resulting from the clicks on your ads that have received co-bids from your manufacturer partners. */
+        /** The number of conversions. */
         const AssistedConversions = 'AssistedConversions';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The revenue optionally reported by the advertiser as a result of conversions. */
+        const AllRevenue = 'AllRevenue';
+
+        /** The conversion rate as a percentage. */
+        const AllConversionRate = 'AllConversionRate';
+
+        /** The cost per conversion. */
+        const AllCostPerConversion = 'AllCostPerConversion';
+
+        /** The return on ad spend (ROAS). */
+        const AllReturnOnAdSpend = 'AllReturnOnAdSpend';
+
+        /** The revenue per conversion. */
+        const AllRevenuePerConversion = 'AllRevenuePerConversion';
+
+        /** The cost per conversion. */
+        const CostPerConversion = 'CostPerConversion';
     }
 
 }

--- a/src/V13/Reporting/ProductPartitionPerformanceReportColumn.php
+++ b/src/V13/Reporting/ProductPartitionPerformanceReportColumn.php
@@ -185,8 +185,26 @@ namespace Microsoft\BingAds\V13\Reporting;
         /** The number of times your ad is shown in the top position as a percentage of the total available impressions in the market you were targeting. */
         const AbsoluteTopImpressionSharePercent = 'AbsoluteTopImpressionSharePercent';
 
-        /** Conversions resulting from the clicks on your ads that have received co-bids from your manufacturer partners. */
+        /** The number of conversions. */
         const AssistedConversions = 'AssistedConversions';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The revenue optionally reported by the advertiser as a result of conversions. */
+        const AllRevenue = 'AllRevenue';
+
+        /** The conversion rate as a percentage. */
+        const AllConversionRate = 'AllConversionRate';
+
+        /** The cost per conversion. */
+        const AllCostPerConversion = 'AllCostPerConversion';
+
+        /** The return on ad spend (ROAS). */
+        const AllReturnOnAdSpend = 'AllReturnOnAdSpend';
+
+        /** The revenue per conversion. */
+        const AllRevenuePerConversion = 'AllRevenuePerConversion';
     }
 
 }

--- a/src/V13/Reporting/ProductPartitionUnitPerformanceReportColumn.php
+++ b/src/V13/Reporting/ProductPartitionUnitPerformanceReportColumn.php
@@ -143,8 +143,26 @@ namespace Microsoft\BingAds\V13\Reporting;
         /** Clicks on your ads that have received co-bids from your manufacturer partners. */
         const AssistedClicks = 'AssistedClicks';
 
-        /** Conversions resulting from the clicks on your ads that have received co-bids from your manufacturer partners. */
+        /** The number of conversions. */
         const AssistedConversions = 'AssistedConversions';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The revenue optionally reported by the advertiser as a result of conversions. */
+        const AllRevenue = 'AllRevenue';
+
+        /** The conversion rate as a percentage. */
+        const AllConversionRate = 'AllConversionRate';
+
+        /** The cost per conversion. */
+        const AllCostPerConversion = 'AllCostPerConversion';
+
+        /** The return on ad spend (ROAS). */
+        const AllReturnOnAdSpend = 'AllReturnOnAdSpend';
+
+        /** The revenue per conversion. */
+        const AllRevenuePerConversion = 'AllRevenuePerConversion';
     }
 
 }

--- a/src/V13/Reporting/ProductSearchQueryPerformanceReportColumn.php
+++ b/src/V13/Reporting/ProductSearchQueryPerformanceReportColumn.php
@@ -131,8 +131,23 @@ namespace Microsoft\BingAds\V13\Reporting;
         /** Clicks on your ads that have received co-bids from your manufacturer partners. */
         const AssistedClicks = 'AssistedClicks';
 
-        /** Conversions resulting from the clicks on your ads that have received co-bids from your manufacturer partners. */
+        /** The number of conversions. */
         const AssistedConversions = 'AssistedConversions';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The revenue optionally reported by the advertiser as a result of conversions. */
+        const AllRevenue = 'AllRevenue';
+
+        /** The conversion rate as a percentage. */
+        const AllConversionRate = 'AllConversionRate';
+
+        /** The cost per conversion. */
+        const AllCostPerConversion = 'AllCostPerConversion';
+
+        /** The revenue per conversion. */
+        const AllRevenuePerConversion = 'AllRevenuePerConversion';
     }
 
 }

--- a/src/V13/Reporting/ProfessionalDemographicsAudienceReportColumn.php
+++ b/src/V13/Reporting/ProfessionalDemographicsAudienceReportColumn.php
@@ -56,7 +56,7 @@ namespace Microsoft\BingAds\V13\Reporting;
         /** The sum of your cost-per-click (CPC) charges for your ads and keywords. */
         const Spend = 'Spend';
 
-        /** A conversion is a click that results in a sale or another measure of success. */
+        /** The number of conversions. */
         const Conversions = 'Conversions';
 
         /** This is the language of the country the ad is served in. */
@@ -76,6 +76,15 @@ namespace Microsoft\BingAds\V13\Reporting;
 
         /** The ad group status. */
         const AdGroupStatus = 'AdGroupStatus';
+
+        /** The average position of the ad on a webpage. */
+        const AveragePosition = 'AveragePosition';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The revenue optionally reported by the advertiser as a result of conversions. */
+        const AllRevenue = 'AllRevenue';
     }
 
 }

--- a/src/V13/Reporting/PublisherUsagePerformanceReportColumn.php
+++ b/src/V13/Reporting/PublisherUsagePerformanceReportColumn.php
@@ -118,6 +118,24 @@ namespace Microsoft\BingAds\V13\Reporting;
 
         /** The ad group status. */
         const AdGroupStatus = 'AdGroupStatus';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The revenue optionally reported by the advertiser as a result of conversions. */
+        const AllRevenue = 'AllRevenue';
+
+        /** The conversion rate as a percentage. */
+        const AllConversionRate = 'AllConversionRate';
+
+        /** The cost per conversion. */
+        const AllCostPerConversion = 'AllCostPerConversion';
+
+        /** The return on ad spend (ROAS). */
+        const AllReturnOnAdSpend = 'AllReturnOnAdSpend';
+
+        /** The revenue per conversion. */
+        const AllRevenuePerConversion = 'AllRevenuePerConversion';
     }
 
 }

--- a/src/V13/Reporting/ReportRequestStatus.php
+++ b/src/V13/Reporting/ReportRequestStatus.php
@@ -13,7 +13,7 @@ namespace Microsoft\BingAds\V13\Reporting;
     final class ReportRequestStatus
     {
         /**
-         * The URL from where the report can be downloaded.
+         * The encoded URL from where the report can be downloaded.
          * @var string
          */
         public $ReportDownloadUrl;

--- a/src/V13/Reporting/SearchQueryPerformanceReportColumn.php
+++ b/src/V13/Reporting/SearchQueryPerformanceReportColumn.php
@@ -145,6 +145,24 @@ namespace Microsoft\BingAds\V13\Reporting;
 
         /** The customer name. */
         const CustomerName = 'CustomerName';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The revenue optionally reported by the advertiser as a result of conversions. */
+        const AllRevenue = 'AllRevenue';
+
+        /** The conversion rate as a percentage. */
+        const AllConversionRate = 'AllConversionRate';
+
+        /** The cost per conversion. */
+        const AllCostPerConversion = 'AllCostPerConversion';
+
+        /** The return on ad spend (ROAS). */
+        const AllReturnOnAdSpend = 'AllReturnOnAdSpend';
+
+        /** The revenue per conversion. */
+        const AllRevenuePerConversion = 'AllRevenuePerConversion';
     }
 
 }

--- a/src/V13/Reporting/ShareOfVoiceReportColumn.php
+++ b/src/V13/Reporting/ShareOfVoiceReportColumn.php
@@ -157,6 +157,18 @@ namespace Microsoft\BingAds\V13\Reporting;
 
         /** The percentage of times your ad showed in the mainline, the top placement where ads appear above the search results, out of your total impressions. */
         const TopImpressionRatePercent = 'TopImpressionRatePercent';
+
+        /** The Microsoft Advertising assigned identifier of an experiment campaign. */
+        const BaseCampaignId = 'BaseCampaignId';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The conversion rate as a percentage. */
+        const AllConversionRate = 'AllConversionRate';
+
+        /** The cost per conversion. */
+        const AllCostPerConversion = 'AllCostPerConversion';
     }
 
 }

--- a/src/V13/Reporting/UserLocationPerformanceReportColumn.php
+++ b/src/V13/Reporting/UserLocationPerformanceReportColumn.php
@@ -154,6 +154,24 @@ namespace Microsoft\BingAds\V13\Reporting;
 
         /** The location identifier if the user's geographical intent can be determined. */
         const QueryIntentLocationId = 'QueryIntentLocationId';
+
+        /** The number of conversions. */
+        const AllConversions = 'AllConversions';
+
+        /** The revenue optionally reported by the advertiser as a result of conversions. */
+        const AllRevenue = 'AllRevenue';
+
+        /** The conversion rate as a percentage. */
+        const AllConversionRate = 'AllConversionRate';
+
+        /** The cost per conversion. */
+        const AllCostPerConversion = 'AllCostPerConversion';
+
+        /** The return on ad spend (ROAS). */
+        const AllReturnOnAdSpend = 'AllReturnOnAdSpend';
+
+        /** The revenue per conversion. */
+        const AllRevenuePerConversion = 'AllRevenuePerConversion';
     }
 
 }


### PR DESCRIPTION
Updated Bing Ads API version 12 and 13 service proxies to reflect recent interface changes. For more information please see the [Bing Ads API Release Notes](https://docs.microsoft.com/en-us/advertising/guides/release-notes).

Added the SoapClient User-Agent header.