### PR TITLE
Passing the $error and $description parameters to the \Exception relevant properties

### DIFF
--- a/src/Auth/OAuthTokenRequestException.php
+++ b/src/Auth/OAuthTokenRequestException.php
@@ -4,37 +4,39 @@ namespace Microsoft\BingAds\Auth;
 
 use Exception;
 
-/** 
- * Represents an OAuth token request exception. 
+/**
+ * Represents an OAuth token request exception.
  */
 class OAuthTokenRequestException extends Exception
-{   
+{
     public $Error;
     public $Description;
 
     public function __construct() {}
 
-    /** 
+    /**
      * Includes the error.
-     * 
+     *
      * @param string $error
      *
      * @return OAuthTokenRequestException
      */
     public function withError($error) {
         $this->Error = $error;
+        $this->code = $error;
         return $this;
     }
 
-    /** 
+    /**
      * Includes the error description.
-     * 
+     *
      * @param string $description
      *
      * @return OAuthTokenRequestException
      */
     public function withDescription($description) {
         $this->Description = $description;
+        $this->message = $description;
         return $this;
     }
 }


### PR DESCRIPTION
Passing the $error and $description parameters to the \Exception $code and $message properties so that PHP can correctly Throw a message.