### PR TITLE
Fix for WebAuthentication sample

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Microsoft\\BingAds\\": "/src/"
+            "Microsoft\\BingAds\\": "src/"
         }
     },
     "authors": [


### PR DESCRIPTION
Addresses issue #125 

The src path in composer.json was causing the following error to be thrown when using the web auth sample: 

> PHP Fatal error: Class 'Microsoft\BingAds\Auth\OAuthWebAuthCodeGrant' 