### PR TITLE
Tenant setting with msads.manage OAuth scope

### DIFF
--- a/src/Auth/UriOAuthService.php
+++ b/src/Auth/UriOAuthService.php
@@ -81,7 +81,7 @@ class UriOAuthService extends IOAuthService
         
         $OAuthTokenUrl = UriOAuthService::ENDPOINT_URLS[$endpointType]['OAuthTokenUrl'];
 
-        if ((strcmp($endpointType, OAuthEndpointType::ProductionMSIdentityV2) == 0) && (isset($tenant)))
+        if (in_array($endpointType, [OAuthEndpointType::ProductionMSIdentityV2, OAuthEndpointType::ProductionMSIdentityV2_MSScope], true) && (isset($tenant)))
         {
             $OAuthTokenUrl = str_replace("common", $tenant, $OAuthTokenUrl);
         }
@@ -152,9 +152,9 @@ class UriOAuthService extends IOAuthService
 
         $authorizationEndpointUrl = UriOAuthService::ENDPOINT_URLS[$endpointType]['AuthorizationEndpointUrl'];
         
-        if ((strcmp($endpointType, OAuthEndpointType::ProductionMSIdentityV2) == 0) && (isset($tenant)))
+        if (in_array($endpointType, [OAuthEndpointType::ProductionMSIdentityV2, OAuthEndpointType::ProductionMSIdentityV2_MSScope], true) && (isset($tenant)))
         {
-            $authorizationEndpointUrl = str_replace("common", $tenant, $authorizationEndpointUrl);
+            $OAuthTokenUrl = str_replace("common", $tenant, $OAuthTokenUrl);
         }
 
         return sprintf(
@@ -202,7 +202,7 @@ class UriOAuthService extends IOAuthService
 
         $OAuthTokenUrl = UriOAuthService::ENDPOINT_URLS[$endpointType]['OAuthTokenUrl'];
 
-        if ((strcmp($endpointType, OAuthEndpointType::ProductionMSIdentityV2) == 0) && (isset($tenant)))
+        if (in_array($endpointType, [OAuthEndpointType::ProductionMSIdentityV2, OAuthEndpointType::ProductionMSIdentityV2_MSScope], true) && (isset($tenant)))
         {
             $OAuthTokenUrl = str_replace("common", $tenant, $OAuthTokenUrl);
         }
@@ -215,9 +215,9 @@ class UriOAuthService extends IOAuthService
 
         $authorizationEndpointUrl = UriOAuthService::ENDPOINT_URLS[$endpointType]['AuthorizationEndpointUrl'];
         
-        if ((strcmp($endpointType, OAuthEndpointType::ProductionMSIdentityV2) == 0) && (isset($tenant)))
+        if (in_array($endpointType, [OAuthEndpointType::ProductionMSIdentityV2, OAuthEndpointType::ProductionMSIdentityV2_MSScope], true) && (isset($tenant)))
         {
-            $authorizationEndpointUrl = str_replace("common", $tenant, $authorizationEndpointUrl);
+            $OAuthTokenUrl = str_replace("common", $tenant, $OAuthTokenUrl);
         }
 
         return $authorizationEndpointUrl;


### PR DESCRIPTION
The `msads.manage` OAuth scope does not currently work for single tenant applications. The new scope was added [in the 13.0.10 release](https://github.com/BingAds/BingAds-PHP-SDK/commit/0c06e82991d2213af72b0684826e57a320cd7176), but these changes miss adding support for [the tenant parameter](https://github.com/BingAds/BingAds-PHP-SDK/commit/e651112f2b9f3df39320f9abd0194043b10009fc).

This results in the following error:

```Usage of the /common endpoint is not supported for such applications created after '10/15/2018'. Use a tenant-specific endpoint or configure the application to be multi-tenant.```