### PR TITLE
Fix typehint on with OAuthTokens

### DIFF
--- a/src/Auth/OAuthAuthorization.php
+++ b/src/Auth/OAuthAuthorization.php
@@ -81,7 +81,7 @@ abstract class OAuthAuthorization extends Authentication
     /** 
      * Includes the OAuth tokens. 
      *
-     * @param string $oauthTokens
+     * @param OAuthTokens $oauthTokens
      * @return OAuthAuthorization this builder
      */
     public function withOAuthTokens($oauthTokens) {


### PR DESCRIPTION
This method accepts a string, but the parameter actually should be an `OAuthTokens` object (also see what `withRefreshToken` does, as that creates the `OAuthTokens` object first)